### PR TITLE
Render legacy youtube shortcodes as real embeds

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -146,6 +146,15 @@ a:hover {
   @apply mb-0;
 }
 
+/* Expanded from the legacy {{ youtube(id="...") }} shortcode. */
+.youtube-embed {
+  @apply mb-4 overflow-hidden rounded;
+  aspect-ratio: 16 / 9;
+}
+.youtube-embed iframe {
+  @apply h-full w-full border-0;
+}
+
 /* highlight.js atom-one-dark theme (vendored from node_modules) */
 pre code.hljs {
   display: block;

--- a/lib/blog/content.ex
+++ b/lib/blog/content.ex
@@ -61,12 +61,30 @@ defmodule Blog.Content do
     Repo.exists?(Post)
   end
 
+  # Legacy Zola shortcode, e.g. {{ youtube(id="xbeH4Dogn2A") }}. The id
+  # charset is restricted so nothing else can be smuggled into the iframe src.
+  @youtube_shortcode ~r/\{\{\s*youtube\(\s*id\s*=\s*["']([A-Za-z0-9_-]+)["']\s*\)\s*\}\}/
+  @any_shortcode ~r/\{\{[^{}]*\}\}/
+
   @doc "Renders a post's markdown body to HTML."
-  def render_body(%Post{body: body}) do
-    case Earmark.as_html(body || "") do
+  def render_body(%Post{body: body}), do: render_markdown(body)
+
+  @doc "Renders a markdown string (with legacy shortcodes expanded) to HTML."
+  def render_markdown(body) do
+    body = expand_shortcodes(body || "")
+
+    case Earmark.as_html(body) do
       {:ok, html, _} -> html
       {:error, html, _errors} -> html
     end
+  end
+
+  defp expand_shortcodes(body) do
+    Regex.replace(@youtube_shortcode, body, fn _, id -> youtube_embed(id) end)
+  end
+
+  defp youtube_embed(id) do
+    ~s(<div class="youtube-embed"><iframe src="https://www.youtube-nocookie.com/embed/#{id}" title="YouTube video player" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>)
   end
 
   @doc """
@@ -80,6 +98,7 @@ defmodule Blog.Content do
   def excerpt(body, max) when is_binary(body) do
     text =
       body
+      |> String.replace(@any_shortcode, " ")
       |> String.replace(~r/```.*?```/s, " ")
       |> String.replace(~r/`[^`]*`/, " ")
       |> String.replace(~r/<[^>]+>/, " ")

--- a/lib/blog_web/live/admin/post_form_live.ex
+++ b/lib/blog_web/live/admin/post_form_live.ex
@@ -79,14 +79,7 @@ defmodule BlogWeb.Admin.PostFormLive do
     assign(socket, form: to_form(changeset))
   end
 
-  defp render_preview(nil), do: ""
-
-  defp render_preview(body) do
-    case Earmark.as_html(body) do
-      {:ok, html, _} -> html
-      {:error, html, _} -> html
-    end
-  end
+  defp render_preview(body), do: Content.render_markdown(body)
 
   defp slugify(title) do
     title

--- a/test/blog/content_test.exs
+++ b/test/blog/content_test.exs
@@ -49,6 +49,31 @@ defmodule Blog.ContentTest do
     assert Content.render_body(post) =~ "<strong>hi</strong>"
   end
 
+  test "render_body/1 expands the legacy youtube shortcode into an iframe" do
+    body = ~s|Intro\n\n{{ youtube(id="xbeH4Dogn2A") }}\n\nOutro|
+    {:ok, post} = Content.create_post(%{@valid_attrs | body: body})
+    html = Content.render_body(post)
+
+    assert html =~ ~s(src="https://www.youtube-nocookie.com/embed/xbeH4Dogn2A")
+    assert html =~ ~s(class="youtube-embed")
+    refute html =~ "{{"
+  end
+
+  test "render_markdown/1 expands a shortcode indented inside an HTML block" do
+    body = "<div class=\" mb-4\">\n    {{ youtube(id=\"yNTmFORn3xQ\") }}\n</div>"
+    html = Content.render_markdown(body)
+
+    assert html =~ ~s(src="https://www.youtube-nocookie.com/embed/yNTmFORn3xQ")
+    refute html =~ "{{"
+  end
+
+  test "render_markdown/1 leaves shortcodes with unsafe ids untouched" do
+    body = ~s|{{ youtube(id="abc" onload="alert(1)") }}|
+    html = Content.render_markdown(body)
+
+    refute html =~ "<iframe"
+  end
+
   test "get_published_by_slug/1 returns nil for drafts" do
     {:ok, _} = Content.create_post(%{@valid_attrs | published: false})
     assert Content.get_published_by_slug("hello-world") == nil
@@ -72,6 +97,15 @@ defmodule Blog.ContentTest do
     refute excerpt =~ "<"
     refute excerpt =~ "img"
     assert excerpt =~ "Hello there."
+  end
+
+  test "excerpt/2 strips legacy shortcodes" do
+    body = ~s|{{ youtube(id="xbeH4Dogn2A") }}\n\nA great video.|
+    excerpt = Content.excerpt(body)
+
+    refute excerpt =~ "youtube"
+    refute excerpt =~ "{{"
+    assert excerpt =~ "A great video."
   end
 
   test "excerpt/2 truncates on a word boundary with an ellipsis" do


### PR DESCRIPTION
Legacy Zola posts contain {{ youtube(id="...") }} shortcodes that were
showing up as literal text. Expand them at render time into a responsive,
lazy-loaded youtube-nocookie iframe, reuse the same renderer for the admin
preview, and strip shortcodes from meta-description excerpts.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Am2TwnofmUE3gnhTF3LHUV