### PR TITLE
Refactor Sea easter egg from theme toggle to dedicated /sea route

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -336,31 +336,6 @@ pre code.hljs {
   text-transform: uppercase; letter-spacing: 0.02em; white-space: nowrap;
   background: var(--color-paper); border: 2px solid var(--color-ink);
   padding: 5px 10px; pointer-events: none; opacity: 0; transition: opacity 150ms ease; }
-.sea-hint { position: absolute; top: 16px; left: 88px; right: 0; text-align: center;
+.sea-hint { position: absolute; top: 16px; left: 0; right: 0; text-align: center;
   font-size: 12px; letter-spacing: .06em; text-transform: uppercase;
   color: var(--color-ink-2); pointer-events: none; }
-
-/* Anchoring bar: a collapsed echo of the site's sidebar, kept on screen while
-   sailing so the 3D view never feels fully detached from the rest of the
-   site. A vertical rail on the left at desktop widths; a horizontal strip
-   across the top on narrow/mobile viewports. */
-.sea-anchor { position: absolute; z-index: 2; top: 0; left: 0; bottom: 0; width: 88px;
-  display: flex; flex-direction: column; align-items: center; justify-content: space-between;
-  gap: 12px; padding: 16px 0; background: var(--color-paper);
-  border-right: 2px solid var(--color-ink); }
-.sea-anchor-face { display: block; box-shadow: none; }
-.sea-anchor-face img { display: block; width: 52px; height: 52px; object-fit: cover;
-  object-position: 50% 20%; border: 2px solid var(--color-ink); filter: grayscale(1) contrast(1.1); }
-.sea-anchor-leave { width: 44px; height: 44px; border: 2px solid var(--color-ink);
-  background: var(--color-paper); color: var(--color-ink); font-size: 20px; font-weight: 700;
-  line-height: 1; display: flex; align-items: center; justify-content: center; }
-.sea-anchor-leave:hover { background: var(--color-lime); color: var(--on-lime); }
-
-@media (max-width: 767px) {
-  .sea-anchor { top: 0; left: 0; right: 0; bottom: auto; width: auto; height: 64px;
-    flex-direction: row; padding: 0 14px; border-right: none;
-    border-bottom: 2px solid var(--color-ink); }
-  .sea-anchor-face img { width: 38px; height: 38px; }
-  .sea-anchor-leave { width: 38px; height: 38px; font-size: 17px; }
-  .sea-hint { top: 76px; left: 0; }
-}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -3,6 +3,7 @@ import "phoenix_html"
 import {Socket} from "phoenix"
 import {LiveSocket} from "phoenix_live_view"
 import hljs from "highlight.js/lib/common"
+import {seaBus} from "./sea/bus.js"
 
 // Syntax-highlight code blocks in rendered markdown. Earmark emits
 // <pre><code class="elixir">…</code></pre>; highlight.js reads that class.
@@ -20,8 +21,8 @@ let Hooks = {
   },
   // Light/dark theme toggle. Theme is a pure client concern: flip
   // dataset.theme on <html> and persist to localStorage. The label always
-  // names the theme you'd switch TO. Sea is a separate control (SeaToggle) —
-  // this toggle only ever moves between light and dark.
+  // names the theme you'd switch TO. The 3D sea lives at its own route
+  // (/sea), not a theme.
   ThemeToggle: {
     mounted() {
       const sync = () => {
@@ -38,63 +39,131 @@ let Hooks = {
       })
     }
   },
-  // Mounts/unmounts the 3D sea when the theme is "sea". The heavy three.js
-  // bundle is only imported the first time it's needed.
+  // Boots the 3D sea. Lives on the /sea route's own root element, so it
+  // mounts/unmounts on LiveView's normal navigation lifecycle instead of a
+  // separate toggle button racing a theme-change event. The heavy three.js
+  // bundle is only imported once this page actually mounts.
   SeaMode: {
-    async enter() {
-      if (this.running) return
-      this.running = true
-      sessionStorage.removeItem("seaActive")
-      this.el.classList.remove("hidden")
-      const [mod, res] = await Promise.all([
-        import("/assets/js/sea/index.js"),
-        fetch("/sea/islands.json")
-      ])
-      this.sea = mod
-      const {islands} = await res.json()
-      mod.startSea({el: this.el, sailorId: window.SAILOR_ID, islands})
-    },
-    exit() {
-      if (!this.running) return
-      this.running = false
-      if (this.sea) this.sea.stopSea()
-      this.el.classList.add("hidden")
-    },
     mounted() {
-      this.onTheme = (e) => (e.detail.theme === "sea" ? this.enter() : this.exit())
-      document.addEventListener("theme:changed", this.onTheme)
-      // Honor a persisted "sea" theme on first load.
-      if (document.documentElement.dataset.theme === "sea") this.enter()
+      this.running = true
+      Promise.all([import("/assets/js/sea/index.js"), fetch("/sea/islands.json")]).then(
+        async ([mod, res]) => {
+          if (!this.running) return // navigated away before the bundle loaded
+          this.sea = mod
+          const {islands} = await res.json()
+          mod.startSea({el: this.el, sailorId: window.SAILOR_ID, islands})
+        }
+      )
     },
     destroyed() {
-      document.removeEventListener("theme:changed", this.onTheme)
-      this.exit()
+      this.running = false
+      if (this.sea) this.sea.stopSea()
+      sessionStorage.removeItem("seaActive")
     }
   },
-  // Dedicated control for the Sea easter egg, separate from Light/Dark.
-  // Doubles as "return to your boat": if a sea session is paused (docked at a
-  // post), the same button's label switches to say so and clicking it jumps
-  // straight back into Sea mode at the saved position.
-  SeaToggle: {
+  // Sidebar minimap on the /sea page: draws islands + other sailors from
+  // "tick" events published by the sea scene, and lets a click steer the
+  // boat there via a "navigate" event. Statically bundled (no three.js), so
+  // it renders immediately even while the 3D scene is still loading.
+  SeaMinimap: {
+    mounted() {
+      this.ctx = this.el.getContext("2d")
+      this.w = this.el.width
+      this.h = this.el.height
+      this.state = null
+
+      this.onTick = (e) => {
+        this.state = e.detail
+        this.draw()
+      }
+      seaBus.addEventListener("tick", this.onTick)
+
+      this.el.addEventListener("click", (e) => {
+        if (!this.state) return
+        const rect = this.el.getBoundingClientRect()
+        const px = ((e.clientX - rect.left) / rect.width) * this.w
+        const py = ((e.clientY - rect.top) / rect.height) * this.h
+        const {x, z} = this.toWorld(px, py)
+        seaBus.dispatchEvent(new CustomEvent("navigate", {detail: {x, z}}))
+      })
+    },
+    // World bounds padded a bit beyond the islands so boats near the edge
+    // aren't drawn right on the frame.
+    bounds() {
+      const pts = [{x: 0, z: 0}, ...this.state.islands, ...this.state.boats, this.state.self]
+      const xs = pts.map((p) => p.x)
+      const zs = pts.map((p) => p.z)
+      const pad = 20
+      return {
+        minX: Math.min(...xs) - pad,
+        maxX: Math.max(...xs) + pad,
+        minZ: Math.min(...zs) - pad,
+        maxZ: Math.max(...zs) + pad
+      }
+    },
+    toScreen(x, z, b) {
+      return {
+        px: ((x - b.minX) / (b.maxX - b.minX)) * this.w,
+        py: ((z - b.minZ) / (b.maxZ - b.minZ)) * this.h
+      }
+    },
+    toWorld(px, py) {
+      const b = this.bounds()
+      return {
+        x: b.minX + (px / this.w) * (b.maxX - b.minX),
+        z: b.minZ + (py / this.h) * (b.maxZ - b.minZ)
+      }
+    },
+    draw() {
+      const {ctx, w, h, state} = this
+      ctx.clearRect(0, 0, w, h)
+      const b = this.bounds()
+
+      ctx.fillStyle = "rgba(26, 28, 32, 0.35)"
+      for (const isl of state.islands) {
+        const {px, py} = this.toScreen(isl.x, isl.z, b)
+        ctx.beginPath()
+        ctx.arc(px, py, 2.5, 0, Math.PI * 2)
+        ctx.fill()
+      }
+
+      ctx.fillStyle = "#1a1c20"
+      for (const boat of state.boats) {
+        const {px, py} = this.toScreen(boat.x, boat.z, b)
+        ctx.beginPath()
+        ctx.arc(px, py, 3.5, 0, Math.PI * 2)
+        ctx.fill()
+      }
+
+      const self = this.toScreen(state.self.x, state.self.z, b)
+      ctx.fillStyle = "#c4e600"
+      ctx.strokeStyle = "#1a1c20"
+      ctx.lineWidth = 1.5
+      ctx.beginPath()
+      ctx.arc(self.px, self.py, 4.5, 0, Math.PI * 2)
+      ctx.fill()
+      ctx.stroke()
+    },
+    destroyed() {
+      seaBus.removeEventListener("tick", this.onTick)
+    }
+  },
+  // Top-of-page banner offering a way back into the sea, shown on every page
+  // except /sea itself once a sea session has been paused (docked at a
+  // post). Dismissing it hides it for the rest of this paused session; it
+  // re-appears the next time the sailor docks somewhere new.
+  SeaBanner: {
     sync() {
-      const paused = sessionStorage.seaActive === "1"
-      this.el.textContent = paused ? "⛵ Back to boat" : "⛵ Explore in 3D"
+      const show =
+        sessionStorage.seaActive === "1" && sessionStorage.seaBannerDismissed !== "1"
+      this.el.style.display = show ? "flex" : "none"
     },
     mounted() {
       this.sync()
-      this.onTheme = () => this.sync()
-      document.addEventListener("theme:changed", this.onTheme)
-      this.el.addEventListener("click", () => {
-        const current = document.documentElement.dataset.theme
-        if (current !== "sea") localStorage.themePrev = current
-        const theme = "sea"
-        document.documentElement.dataset.theme = theme
-        localStorage.theme = theme
-        document.dispatchEvent(new CustomEvent("theme:changed", {detail: {theme}}))
+      this.el.querySelector("[data-dismiss]").addEventListener("click", () => {
+        sessionStorage.seaBannerDismissed = "1"
+        this.sync()
       })
-    },
-    destroyed() {
-      document.removeEventListener("theme:changed", this.onTheme)
     }
   },
   // LiveView has no native phx-dblclick; bridge a dblclick into a server event.

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -76,7 +76,7 @@ let Hooks = {
         this.state = e.detail
         this.draw()
       }
-      seaBus.addEventListener("tick", this.onTick)
+      seaBus.addEventListener("sea:tick", this.onTick)
 
       this.el.addEventListener("click", (e) => {
         if (!this.state) return
@@ -84,7 +84,7 @@ let Hooks = {
         const px = ((e.clientX - rect.left) / rect.width) * this.w
         const py = ((e.clientY - rect.top) / rect.height) * this.h
         const {x, z} = this.toWorld(px, py)
-        seaBus.dispatchEvent(new CustomEvent("navigate", {detail: {x, z}}))
+        seaBus.dispatchEvent(new CustomEvent("sea:navigate", {detail: {x, z}}))
       })
     },
     // World bounds padded a bit beyond the islands so boats near the edge
@@ -145,7 +145,7 @@ let Hooks = {
       ctx.stroke()
     },
     destroyed() {
-      seaBus.removeEventListener("tick", this.onTick)
+      seaBus.removeEventListener("sea:tick", this.onTick)
     }
   },
   // Top-of-page banner offering a way back into the sea, shown on every page

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -114,12 +114,18 @@ let Hooks = {
         z: b.minZ + (py / this.h) * (b.maxZ - b.minZ)
       }
     },
+    // Read live theme tokens rather than hardcoding hex — the minimap must
+    // stay legible whichever of light/dark is active, and canvas fillStyle
+    // accepts the same oklch() values the CSS custom properties use.
+    themeColor(name) {
+      return getComputedStyle(document.documentElement).getPropertyValue(name).trim()
+    },
     draw() {
       const {ctx, w, h, state} = this
       ctx.clearRect(0, 0, w, h)
       const b = this.bounds()
 
-      ctx.fillStyle = "rgba(26, 28, 32, 0.35)"
+      ctx.fillStyle = this.themeColor("--color-ink-3")
       for (const isl of state.islands) {
         const {px, py} = this.toScreen(isl.x, isl.z, b)
         ctx.beginPath()
@@ -127,7 +133,7 @@ let Hooks = {
         ctx.fill()
       }
 
-      ctx.fillStyle = "#1a1c20"
+      ctx.fillStyle = this.themeColor("--color-signal")
       for (const boat of state.boats) {
         const {px, py} = this.toScreen(boat.x, boat.z, b)
         ctx.beginPath()
@@ -136,8 +142,8 @@ let Hooks = {
       }
 
       const self = this.toScreen(state.self.x, state.self.z, b)
-      ctx.fillStyle = "#c4e600"
-      ctx.strokeStyle = "#1a1c20"
+      ctx.fillStyle = this.themeColor("--color-lime")
+      ctx.strokeStyle = this.themeColor("--color-ink")
       ctx.lineWidth = 1.5
       ctx.beginPath()
       ctx.arc(self.px, self.py, 4.5, 0, Math.PI * 2)

--- a/assets/js/sea/bus.js
+++ b/assets/js/sea/bus.js
@@ -1,0 +1,5 @@
+// Tiny event bus shared between the sea scene (loaded lazily, drags in
+// three.js) and lightweight sidebar hooks like the minimap (always loaded
+// with the main bundle). Keeping this file dependency-free means the minimap
+// never has to wait on — or trigger — the heavy three.js import.
+export const seaBus = new EventTarget()

--- a/assets/js/sea/bus.js
+++ b/assets/js/sea/bus.js
@@ -1,5 +1,9 @@
-// Tiny event bus shared between the sea scene (loaded lazily, drags in
-// three.js) and lightweight sidebar hooks like the minimap (always loaded
-// with the main bundle). Keeping this file dependency-free means the minimap
-// never has to wait on — or trigger — the heavy three.js import.
-export const seaBus = new EventTarget()
+// Event bus shared between the sea scene and lightweight sidebar hooks like
+// the minimap. app.js and sea/index.js are two independent esbuild bundles
+// (the sea scene is lazy-loaded to keep three.js out of the main bundle), so
+// each gets its own copy of any module-level object — a plain EventTarget
+// here would give the scene and the minimap two different instances that
+// never see each other's events. `document` is the one thing both bundles
+// actually share, so it doubles as the bus (same trick as the site's
+// existing "theme:changed" event).
+export const seaBus = document

--- a/assets/js/sea/index.js
+++ b/assets/js/sea/index.js
@@ -64,7 +64,7 @@ class Sea {
       this.pos.z = e.detail.z
       this.speed = 0
     }
-    seaBus.addEventListener("navigate", this.onNavigate)
+    seaBus.addEventListener("sea:navigate", this.onNavigate)
 
     this.t = 0
     this.tickEvery = 6 // throttle minimap updates to ~10Hz at 60fps
@@ -216,7 +216,7 @@ class Sea {
       if (isl) boats.push({id: s.id, x: isl.x + 10, z: isl.z + 10})
     }
     seaBus.dispatchEvent(
-      new CustomEvent("tick", {
+      new CustomEvent("sea:tick", {
         detail: {self: {x: this.pos.x, z: this.pos.z, h: this.pos.h}, boats, islands: this.islands}
       })
     )
@@ -269,7 +269,7 @@ class Sea {
     this.controls.destroy()
     this.net.destroy()
     this.scene.dispose()
-    seaBus.removeEventListener("navigate", this.onNavigate)
+    seaBus.removeEventListener("sea:navigate", this.onNavigate)
     if (this.banner.parentNode) this.banner.remove()
     if (this.hint.parentNode) this.hint.remove()
   }

--- a/assets/js/sea/index.js
+++ b/assets/js/sea/index.js
@@ -2,6 +2,7 @@ import {SeaScene, flagTexture} from "./scene.js"
 import {createControls} from "./controls.js"
 import {SeaNet} from "./net.js"
 import {nearestDockable, nearestIsland, isCloseEnoughToDock, resolveCollision} from "./world.js"
+import {seaBus} from "./bus.js"
 
 const MAX_SPEED = 0.6
 const ACCEL = 0.05
@@ -55,44 +56,18 @@ class Sea {
 
     this.hint = document.createElement("div")
     this.hint.className = "sea-hint"
-    this.hint.textContent = "Arrows / WASD to sail · Space to dock · toggle theme to leave"
+    this.hint.textContent = "Arrows / WASD to sail · Space to dock"
     el.appendChild(this.hint)
 
-    // Anchoring bar: a collapsed echo of the site sidebar (face + exit),
-    // kept on screen so sailing never feels fully detached from the site.
-    // Left rail at desktop widths, top strip on mobile — see .sea-anchor.
-    this.anchor = document.createElement("div")
-    this.anchor.className = "sea-anchor"
-
-    const face = document.createElement("a")
-    face.className = "sea-anchor-face"
-    face.href = "/"
-    face.setAttribute("aria-label", "Dan Bruder — home")
-    const faceImg = document.createElement("img")
-    faceImg.src = "/images/my-face-new.jpg"
-    faceImg.alt = "Dan Bruder"
-    face.appendChild(faceImg)
-
-    this.leaveBtn = document.createElement("button")
-    this.leaveBtn.className = "sea-anchor-leave"
-    this.leaveBtn.type = "button"
-    this.leaveBtn.setAttribute("aria-label", "Leave the sea")
-    this.leaveBtn.title = "Leave the sea"
-    this.leaveBtn.textContent = "×"
-    this.leaveBtn.addEventListener("click", () => {
-      const prev = localStorage.themePrev || "light"
-      sessionStorage.removeItem("seaActive")
-      savePos(this.pos)
-      localStorage.theme = prev
-      document.documentElement.dataset.theme = prev
-      document.dispatchEvent(new CustomEvent("theme:changed", {detail: {theme: prev}}))
-    })
-
-    this.anchor.appendChild(face)
-    this.anchor.appendChild(this.leaveBtn)
-    el.appendChild(this.anchor)
+    this.onNavigate = (e) => {
+      this.pos.x = e.detail.x
+      this.pos.z = e.detail.z
+      this.speed = 0
+    }
+    seaBus.addEventListener("navigate", this.onNavigate)
 
     this.t = 0
+    this.tickEvery = 6 // throttle minimap updates to ~10Hz at 60fps
     this.running = true
     this.loop = this.loop.bind(this)
     requestAnimationFrame(this.loop)
@@ -140,6 +115,7 @@ class Sea {
 
     this.syncOtherBoats()
     this.updateBanner()
+    if (Math.round(this.t * 60) % this.tickEvery === 0) this.publishTick()
 
     if (input.dock) {
       input.dock = false
@@ -223,6 +199,29 @@ class Sea {
     return list
   }
 
+  // Snapshot of everyone's position for the sidebar minimap: live sailors
+  // from net.remote plus anchored readers bobbing at their island — the same
+  // two groups syncOtherBoats() draws in the 3D scene.
+  publishTick() {
+    const boats = []
+    const liveIds = new Set()
+    for (const [id, p] of this.net.remote) {
+      if (id === this.sailorId) continue
+      liveIds.add(id)
+      boats.push({id, x: p.x, z: p.z})
+    }
+    for (const s of this.net.roster) {
+      if (s.id === this.sailorId || liveIds.has(s.id)) continue
+      const isl = this.islandsByPath.get(s.path)
+      if (isl) boats.push({id: s.id, x: isl.x + 10, z: isl.z + 10})
+    }
+    seaBus.dispatchEvent(
+      new CustomEvent("tick", {
+        detail: {self: {x: this.pos.x, z: this.pos.z, h: this.pos.h}, boats, islands: this.islands}
+      })
+    )
+  }
+
   flagFor(id) {
     const s = this.net.roster.find((r) => r.id === id)
     return s ? s.flag : "🏳️"
@@ -255,27 +254,24 @@ class Sea {
   }
 
   dockTo(island) {
-    // Leaving Sea mode to read a post: restore the previous light/dark theme,
-    // then navigate. Mark that a sea session is paused (and save where the
-    // boat was) so the destination page can offer a one-click way back to
-    // the boat, at the same spot.
-    const prev = localStorage.themePrev || "light"
+    // Leaving the sea to read a post. Mark that a sea session is paused (and
+    // save where the boat was) so the destination page can offer a banner
+    // back to the boat, at the same spot.
     sessionStorage.seaActive = "1"
+    sessionStorage.removeItem("seaBannerDismissed")
     savePos(this.pos)
-    localStorage.theme = prev
-    document.documentElement.dataset.theme = prev
-    document.dispatchEvent(new CustomEvent("theme:changed", {detail: {theme: prev}}))
     window.location.href = island.path
   }
 
   destroy() {
     this.running = false
+    savePos(this.pos)
     this.controls.destroy()
     this.net.destroy()
     this.scene.dispose()
+    seaBus.removeEventListener("navigate", this.onNavigate)
     if (this.banner.parentNode) this.banner.remove()
     if (this.hint.parentNode) this.hint.remove()
-    if (this.anchor.parentNode) this.anchor.remove()
   }
 }
 

--- a/lib/blog_web/components/layouts/app.html.heex
+++ b/lib/blog_web/components/layouts/app.html.heex
@@ -1,5 +1,22 @@
 <.flash_group flash={@flash} />
 
+<div
+  id="sea-banner"
+  phx-hook="SeaBanner"
+  style="display: none"
+  class="items-center justify-center gap-3 bg-lime px-4 py-2 text-center text-[12.5px] font-semibold text-on-lime"
+>
+  <a href={~p"/sea"} class="!shadow-none !text-on-lime hover:!underline">
+    ⛵ Continue exploring in 3D →
+  </a>
+  <button
+    type="button"
+    data-dismiss
+    aria-label="Dismiss"
+    class="!shadow-none !text-on-lime text-base leading-none"
+  >×</button>
+</div>
+
 <% nav_items = [
   {"Writing", ~p"/writing", pad(length(Blog.Content.list_published_posts()))},
   {"Notes", ~p"/notes", pad(length(Blog.Content.list_published_notes()))},
@@ -79,12 +96,9 @@ end %>
 
         <%!-- Secondary links --%>
         <div class="flex flex-col items-start gap-1.5 text-[12.5px] text-ink-2">
-          <button
-            id="sea-toggle"
-            phx-hook="SeaToggle"
-            type="button"
-            class="!shadow-none !text-ink-2 hover:!bg-lime hover:!text-on-lime"
-          ></button>
+          <.link navigate={~p"/sea"} class="!shadow-none !text-ink-2 hover:!bg-lime hover:!text-on-lime">
+            ⛵ Explore in 3D
+          </.link>
           <a href="/blog/about" class="!shadow-[inset_0_-1px_0_var(--color-rule)] !text-ink-2">
             About me
           </a>
@@ -117,10 +131,3 @@ end %>
     {@inner_content}
   </main>
 </div>
-
-<div
-  id="sea-overlay"
-  phx-hook="SeaMode"
-  phx-update="ignore"
-  class="fixed inset-0 z-[9999] hidden"
-></div>

--- a/lib/blog_web/components/layouts/sea.html.heex
+++ b/lib/blog_web/components/layouts/sea.html.heex
@@ -1,0 +1,49 @@
+<div class="flex h-[100dvh] flex-col overflow-hidden bg-paper text-ink md:flex-row">
+  <aside class="z-10 flex shrink-0 items-center justify-between gap-3 border-b border-ink bg-paper px-4 py-3 md:h-screen md:w-60 md:flex-col md:items-stretch md:justify-start md:border-b-0 md:border-r md:px-5 md:py-6">
+    <.link
+      navigate={~p"/"}
+      class="flex items-center gap-2 !shadow-none hover:!bg-transparent"
+    >
+      <img
+        src={~p"/images/my-face-new.jpg"}
+        alt="Dan Bruder"
+        class="h-9 w-9 border border-ink object-cover object-[50%_20%] grayscale contrast-[1.1]"
+      />
+      <span class="font-display text-[13px] font-bold tracking-[-0.02em] text-ink">
+        ← Leave the sea
+      </span>
+    </.link>
+
+    <div class="hidden flex-1 flex-col gap-6 md:mt-8 md:flex">
+      <div :if={assigns[:viewer_count]} class="flex items-center gap-2 text-[11.5px] text-ink-2">
+        <span class="inline-block h-2 w-2 bg-lime"></span>
+        {@viewer_count} on the site now
+      </div>
+
+      <div>
+        <p class="label mb-2">Minimap</p>
+        <div class="relative border border-ink bg-paper-3">
+          <canvas id="sea-minimap" phx-hook="SeaMinimap" phx-update="ignore" width="208" height="208" class="block w-full cursor-pointer"></canvas>
+        </div>
+        <p class="mt-2 text-[11px] leading-[1.45] text-ink-3">
+          Dots are other sailors. Click the map to steer your boat toward one.
+        </p>
+      </div>
+
+      <div class="mt-auto text-[11px] leading-[1.45] text-ink-3">
+        Arrows / WASD to sail · Space to dock
+      </div>
+    </div>
+
+    <div :if={assigns[:viewer_count]} class="flex items-center gap-2 text-[11.5px] text-ink-2 md:hidden">
+      <span class="inline-block h-2 w-2 bg-lime"></span>
+      {@viewer_count}
+    </div>
+  </aside>
+
+  <main class="relative min-h-0 flex-1">
+    {@inner_content}
+  </main>
+</div>
+
+<.flash_group flash={@flash} />

--- a/lib/blog_web/components/layouts/sea.html.heex
+++ b/lib/blog_web/components/layouts/sea.html.heex
@@ -20,7 +20,11 @@
         {@viewer_count} on the site now
       </div>
 
-      <div>
+      <div class="text-[11px] leading-[1.45] text-ink-3">
+        Arrows / WASD to sail · Space to dock
+      </div>
+
+      <div class="mt-auto">
         <p class="label mb-2">Minimap</p>
         <div class="relative border border-ink bg-paper-3">
           <canvas id="sea-minimap" phx-hook="SeaMinimap" phx-update="ignore" width="208" height="208" class="block w-full cursor-pointer"></canvas>
@@ -28,10 +32,6 @@
         <p class="mt-2 text-[11px] leading-[1.45] text-ink-3">
           Dots are other sailors. Click the map to steer your boat toward one.
         </p>
-      </div>
-
-      <div class="mt-auto text-[11px] leading-[1.45] text-ink-3">
-        Arrows / WASD to sail · Space to dock
       </div>
     </div>
 

--- a/lib/blog_web/live/post_live/show.ex
+++ b/lib/blog_web/live/post_live/show.ex
@@ -88,6 +88,12 @@ defmodule BlogWeb.PostLive.Show do
         >
           Have a go at the game of snake →
         </.link>
+        <.link
+          navigate={~p"/sea"}
+          class="mt-1 block font-display text-[22px] font-medium leading-[1.2] tracking-[-0.028em] !shadow-none hover:!bg-lime hover:!text-on-lime"
+        >
+          Or explore this site in 3D →
+        </.link>
       </div>
     </article>
     """

--- a/lib/blog_web/live/sea_live.ex
+++ b/lib/blog_web/live/sea_live.ex
@@ -1,0 +1,25 @@
+defmodule BlogWeb.SeaLive do
+  @moduledoc """
+  The Sea easter egg as a real route (`/sea`) instead of a client-side theme
+  toggle. Routing to it and back gives the 3D scene a normal LiveView
+  mount/unmount lifecycle, so the JS hook that boots three.js no longer races
+  against a separate toggle button and `theme:changed` events — it just mounts
+  when this page mounts.
+  """
+
+  use BlogWeb, :live_view
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok,
+     assign(socket, page_title: "Explore in 3D | Dan Bruder"),
+     layout: {BlogWeb.Layouts, :sea}}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div id="sea-root" phx-hook="SeaMode" phx-update="ignore" class="absolute inset-0"></div>
+    """
+  end
+end

--- a/lib/blog_web/router.ex
+++ b/lib/blog_web/router.ex
@@ -34,6 +34,7 @@ defmodule BlogWeb.Router do
       live("/games/sand", SandLive, :index)
       live("/podcasts", PodcastLive.Index, :index)
       live("/projects", ProjectLive.Index, :index)
+      live("/sea", SeaLive, :index)
     end
 
     get("/snake", RedirectController, :snake)


### PR DESCRIPTION
## Summary
Converts the Sea 3D experience from a client-side theme toggle into a proper routed page at `/sea`. This simplifies the architecture by giving the 3D scene a normal LiveView mount/unmount lifecycle instead of racing against theme-change events, and enables new features like a sidebar minimap.

## Key Changes

- **New `/sea` route**: Added `SeaLive` module and dedicated `sea.html.heex` layout with sidebar navigation and minimap canvas
- **Removed theme-based activation**: Eliminated `SeaMode` hook's theme event listeners; now mounts/unmounts naturally with LiveView navigation
- **Event bus for inter-component communication**: Created `seaBus.js` to decouple the heavy three.js scene from lightweight UI components (minimap, banner)
- **Sidebar minimap**: New `SeaMinimap` hook renders islands and other sailors on a canvas, with click-to-navigate steering
- **Sea banner**: Replaced `SeaToggle` button with a dismissible banner on non-sea pages offering to return to a paused session
- **Simplified sea scene**: Removed anchor bar (left/top navigation) from 3D view; navigation now handled by dedicated layout
- **Session persistence**: Uses `sessionStorage.seaActive` to track paused sessions and offer return navigation across pages

## Implementation Details

- The `seaBus` EventTarget is kept dependency-free so the minimap can load immediately without waiting for three.js
- `publishTick()` method broadcasts position snapshots (~10Hz throttled) for minimap updates
- Docking now navigates to the post URL directly instead of toggling theme; previous theme restoration removed
- Canvas minimap uses coordinate transformation to map world positions to screen space with dynamic bounds
- Mobile layout adapts sidebar from vertical rail to horizontal strip via CSS media queries

https://claude.ai/code/session_01XyHRruzfPT9UbUHJ3Qp64S