### PR TITLE
Track admin presence and add sidebar link to admin

### DIFF
--- a/lib/blog_web/components/layouts/app.html.heex
+++ b/lib/blog_web/components/layouts/app.html.heex
@@ -109,6 +109,13 @@ end %>
           >
             GitHub
           </a>
+          <.link
+            :if={assigns[:admin_authenticated]}
+            navigate={~p"/admin"}
+            class="!shadow-[inset_0_-1px_0_var(--color-rule)] !text-ink-2 hover:!text-ink"
+          >
+            Admin
+          </.link>
         </div>
 
         <%!-- Footer: copyright + theme toggle --%>

--- a/lib/blog_web/plugs/admin_auth.ex
+++ b/lib/blog_web/plugs/admin_auth.ex
@@ -4,6 +4,7 @@ defmodule BlogWeb.AdminAuth do
   """
 
   import Plug.Conn
+  import Phoenix.Component, only: [assign: 3]
 
   def init(opts), do: opts
 
@@ -19,10 +20,15 @@ defmodule BlogWeb.AdminAuth do
 
   def on_mount(:ensure_admin, _params, session, socket) do
     if session["admin_authenticated"] do
-      {:cont, socket}
+      {:cont, assign(socket, :admin_authenticated, true)}
     else
       {:halt, Phoenix.LiveView.redirect(socket, to: "/admin/login")}
     end
+  end
+
+  @doc "Assigns `:admin_authenticated` for public pages so the sidebar can link to admin."
+  def on_mount(:assign_admin_flag, _params, session, socket) do
+    {:cont, assign(socket, :admin_authenticated, !!session["admin_authenticated"])}
   end
 
   @doc "Constant-time check against the configured admin password."

--- a/lib/blog_web/plugs/admin_auth.ex
+++ b/lib/blog_web/plugs/admin_auth.ex
@@ -4,7 +4,6 @@ defmodule BlogWeb.AdminAuth do
   """
 
   import Plug.Conn
-  import Phoenix.Component, only: [assign: 3]
 
   def init(opts), do: opts
 
@@ -20,7 +19,7 @@ defmodule BlogWeb.AdminAuth do
 
   def on_mount(:ensure_admin, _params, session, socket) do
     if session["admin_authenticated"] do
-      {:cont, assign(socket, :admin_authenticated, true)}
+      {:cont, Phoenix.Component.assign(socket, :admin_authenticated, true)}
     else
       {:halt, Phoenix.LiveView.redirect(socket, to: "/admin/login")}
     end
@@ -28,7 +27,8 @@ defmodule BlogWeb.AdminAuth do
 
   @doc "Assigns `:admin_authenticated` for public pages so the sidebar can link to admin."
   def on_mount(:assign_admin_flag, _params, session, socket) do
-    {:cont, assign(socket, :admin_authenticated, !!session["admin_authenticated"])}
+    authenticated? = !!session["admin_authenticated"]
+    {:cont, Phoenix.Component.assign(socket, :admin_authenticated, authenticated?)}
   end
 
   @doc "Constant-time check against the configured admin password."

--- a/lib/blog_web/router.ex
+++ b/lib/blog_web/router.ex
@@ -23,7 +23,11 @@ defmodule BlogWeb.Router do
     pipe_through(:browser)
 
     live_session :public,
-      on_mount: [{BlogWeb.PresenceTracker, :track}, {BlogWeb.CurrentPath, :default}] do
+      on_mount: [
+        {BlogWeb.PresenceTracker, :track},
+        {BlogWeb.CurrentPath, :default},
+        {BlogWeb.AdminAuth, :assign_admin_flag}
+      ] do
       live("/", WritingLive, :index)
       live("/writing", WritingLive, :index)
       live("/blog/:slug", PostLive.Show, :show)
@@ -59,7 +63,11 @@ defmodule BlogWeb.Router do
     pipe_through([:browser, :require_admin])
 
     live_session :admin,
-      on_mount: {BlogWeb.AdminAuth, :ensure_admin} do
+      on_mount: [
+        {BlogWeb.AdminAuth, :ensure_admin},
+        {BlogWeb.PresenceTracker, :track},
+        {BlogWeb.CurrentPath, :default}
+      ] do
       live("/", PostIndexLive, :index)
       live("/posts/new", PostFormLive, :new)
       live("/posts/:id/edit", PostFormLive, :edit)


### PR DESCRIPTION
## Summary
- Admin routes (`/admin/*`) weren't wired into `PresenceTracker`, so browsing as an admin never showed up on the viewers page and never populated the sidebar's live viewer count. Both live sessions (`:public` and `:admin`) now share the same `PresenceTracker`/`CurrentPath` `on_mount` hooks, so admin views are tracked like any other viewer.
- Added an "Admin" link at the bottom of the sidebar's secondary links, shown only when the session is authenticated as admin (`assigns[:admin_authenticated]`, assigned via a new `BlogWeb.AdminAuth.on_mount/4` clause on both live sessions).

## Test plan
- [ ] `mix test` (no Elixir toolchain available in this sandbox to run it directly)
- [ ] Manually verify: log in as admin, visit any public page — sidebar shows viewer count and an "Admin" link at the bottom of the secondary links; visit `/admin/viewers` — the admin's own session now appears in the list.


---
_Generated by [Claude Code](https://claude.ai/code/session_018Tpmyp2abqTL6UKhtaNwtd)_