### PR TITLE
Make the admin viewers page react in real time

### DIFF
--- a/lib/blog_web/live/admin/presence_live.ex
+++ b/lib/blog_web/live/admin/presence_live.ex
@@ -6,17 +6,35 @@ defmodule BlogWeb.Admin.PresenceLive do
 
   @impl true
   def mount(_params, _session, socket) do
-    if connected?(socket) do
-      Phoenix.PubSub.subscribe(Blog.PubSub, PresenceTracker.topic())
+    {:ok, assign(socket, page_title: "Viewers")}
+  end
+
+  @doc """
+  Attached ahead of `PresenceTracker`'s own hook in the admin `on_mount` chain
+  (see the router) so `:pages` gets recomputed on every presence_diff before
+  that hook halts the `:handle_info` pipeline to do its own viewer_count
+  bookkeeping.
+  """
+  def on_mount(:track_pages, _params, _session, socket) do
+    if socket.view == __MODULE__ do
+      socket =
+        if connected?(socket) do
+          attach_hook(socket, :presence_live_pages, :handle_info, &handle_presence_diff/2)
+        else
+          socket
+        end
+
+      {:cont, assign(socket, :pages, pages_by_count())}
+    else
+      {:cont, socket}
     end
-
-    {:ok, assign(socket, page_title: "Viewers", pages: pages_by_count())}
   end
 
-  @impl true
-  def handle_info(%{event: "presence_diff"}, socket) do
-    {:noreply, assign(socket, pages: pages_by_count())}
+  defp handle_presence_diff(%{event: "presence_diff"}, socket) do
+    {:cont, assign(socket, :pages, pages_by_count())}
   end
+
+  defp handle_presence_diff(_message, socket), do: {:cont, socket}
 
   defp pages_by_count do
     PresenceTracker.topic() |> Presence.list() |> summarize()

--- a/lib/blog_web/router.ex
+++ b/lib/blog_web/router.ex
@@ -65,6 +65,7 @@ defmodule BlogWeb.Router do
     live_session :admin,
       on_mount: [
         {BlogWeb.AdminAuth, :ensure_admin},
+        {BlogWeb.Admin.PresenceLive, :track_pages},
         {BlogWeb.PresenceTracker, :track},
         {BlogWeb.CurrentPath, :default}
       ] do


### PR DESCRIPTION
## Summary
- The previous PR (#36) added `PresenceTracker`'s `on_mount` hook to the admin `live_session` so admin views would be tracked. That hook attaches a `:handle_info` hook that returns `{:halt, socket}` on `presence_diff` messages (to update the sidebar's `viewer_count`). Halting stops the hook/callback pipeline for that message entirely, so `PresenceLive`'s own `handle_info/2` clause never ran again — the viewers page only reflected presence as of the moment it loaded, and never updated on joins, leaves, or page navigation.
- `PresenceLive` now defines its own `on_mount(:track_pages, ...)` hook, placed **before** `PresenceTracker`'s in the admin `on_mount` list, so it recomputes `:pages` on every `presence_diff` and returns `:cont` — letting `PresenceTracker`'s hook still run afterward for its own bookkeeping. The hook is a no-op for the other admin routes (guarded on `socket.view == __MODULE__`).
- Also removed `PresenceLive`'s now-redundant direct `Phoenix.PubSub.subscribe` in `mount/3`, since `PresenceTracker`'s `on_mount` hook already subscribes the admin route to the presence topic — the LiveView was previously double-subscribed, receiving every broadcast twice.

## Test plan
- [ ] `mix test` (no Elixir toolchain available in this sandbox to run it directly)
- [ ] Manually verify: open `/admin/viewers` in one tab and a public page in another; navigate between pages/leave in the second tab and confirm the admin viewers list updates live without a refresh.


---
_Generated by [Claude Code](https://claude.ai/code/session_018Tpmyp2abqTL6UKhtaNwtd)_