### PR TITLE
Bump actions/checkout and actions/cache to v5 (Node 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       MIX_ENV: test
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: erlef/setup-beam@v1
         with:
@@ -21,7 +21,7 @@ jobs:
           elixir-version: "1.17.3"
 
       - name: Restore deps/build cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             deps
@@ -46,7 +46,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
         with:


### PR DESCRIPTION
## Summary
- CI logs show: "Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/cache@v4, actions/checkout@v4."
- Both `actions/checkout@v4` and `actions/cache@v4` still declare `using: node20` in their `action.yml`, so GitHub Actions is forcibly running them on the Node 24 runtime anyway and logging a deprecation warning on every run.
- Bumped both to `v5`, which declare `using: node24` natively. Verified against each action's `action.yml` on GitHub — inputs (`path`, `key`, `restore-keys` for cache; no changed inputs for checkout) are unchanged, so no other workflow changes are needed.

## Test plan
- [ ] CI run on this PR should be green with no Node 20 deprecation warning in the logs.


---
_Generated by [Claude Code](https://claude.ai/code/session_018Tpmyp2abqTL6UKhtaNwtd)_