### PR TITLE
Redesign islands and boats with multi-band terrain and hull geometry

### DIFF
--- a/assets/js/sea/scene.js
+++ b/assets/js/sea/scene.js
@@ -193,28 +193,77 @@ export class SeaScene {
     }
   }
 
-  // Boat: ink-outlined hull + a sail carrying a flag canvas texture. The hull
-  // color is keyed by sailor id, not by whether it's "you" — so a given
-  // sailor's boat looks the same to every viewer, on every screen. `isSelf`
-  // only adds the ring accent beneath your own boat.
+  // A pointed-bow hull cut from a canoe-shaped outline and tapered inward
+  // toward the deck, instead of a box — the local +Z axis is the bow, to
+  // match how callers set `group.rotation.y` as heading. Built once and
+  // shared (read-only) across every boat instance.
+  _hullGeometry() {
+    if (this._hullGeo) return this._hullGeo
+    const w = 2.4
+    const l = 4.2
+    const hgt = 1.3
+
+    const shape = new THREE.Shape()
+    shape.moveTo(0, -l / 2 - 0.3) // bow tip, raked out ahead of the hull body
+    shape.lineTo(w / 2, -0.5) // starboard shoulder
+    shape.lineTo(w / 2 - 0.3, l / 2) // starboard stern corner
+    shape.lineTo(-(w / 2 - 0.3), l / 2) // port stern corner
+    shape.lineTo(-w / 2, -0.5) // port shoulder
+    shape.closePath()
+
+    const geo = new THREE.ExtrudeGeometry(shape, {depth: hgt, bevelEnabled: false})
+    geo.rotateX(-Math.PI / 2) // shape was drawn top-down; stand the extrusion up
+    geo.translate(0, -hgt / 2, 0) // center vertically, like a BoxGeometry
+
+    // Taper the sides inward toward the deck for a hull-like cross section.
+    const pos = geo.attributes.position
+    for (let i = 0; i < pos.count; i++) {
+      const t = (pos.getY(i) + hgt / 2) / hgt // 0 at keel, 1 at deck
+      pos.setX(i, pos.getX(i) * (1 - 0.35 * t))
+    }
+    pos.needsUpdate = true
+    geo.computeVertexNormals()
+
+    this._hullGeo = geo
+    return geo
+  }
+
+  // Boat: ink-outlined pointed hull + a curved sail carrying a flag canvas
+  // texture. The hull color is keyed by sailor id, not by whether it's
+  // "you" — so a given sailor's boat looks the same to every viewer, on
+  // every screen. `isSelf` only adds the ring accent beneath your own boat.
   makeBoat(flagTexture, isSelf, sailorId) {
     const group = new THREE.Group()
 
-    const hullGeo = new THREE.BoxGeometry(2.4, 1.1, 4.2)
+    const hullGeo = this._hullGeometry()
     const hull = new THREE.Mesh(
       hullGeo,
       new THREE.MeshToonMaterial({color: themedColor(sailorId), gradientMap: this.gradient})
     )
     hull.position.y = 1
-    group.add(outline(hullGeo, 1.12).translateY(1))
+    group.add(outline(hullGeo, 1.1).translateY(1))
     group.add(hull)
+
+    const keelGeo = new THREE.BoxGeometry(0.15, 0.8, 1.8)
+    const keel = new THREE.Mesh(keelGeo, new THREE.MeshBasicMaterial({color: COL.ink}))
+    keel.position.set(0, 0.2, -0.3)
+    group.add(keel)
 
     const mastGeo = new THREE.CylinderGeometry(0.12, 0.12, 4)
     const mast = new THREE.Mesh(mastGeo, new THREE.MeshBasicMaterial({color: COL.ink}))
     mast.position.set(0, 3.2, 0.2)
     group.add(mast)
 
-    const sailGeo = new THREE.PlaneGeometry(2.6, 2.6)
+    // A few extra width segments so the sail can belly out, as if filled
+    // with wind, instead of sitting perfectly flat.
+    const sailGeo = new THREE.PlaneGeometry(2.6, 2.6, 6, 1)
+    const sailPos = sailGeo.attributes.position
+    for (let i = 0; i < sailPos.count; i++) {
+      const t = sailPos.getX(i) / 1.3 // -1..1 across the sail's width
+      sailPos.setZ(i, (1 - t * t) * 0.35)
+    }
+    sailPos.needsUpdate = true
+    sailGeo.computeVertexNormals()
     const sailMat = new THREE.MeshBasicMaterial({
       map: flagTexture,
       side: THREE.DoubleSide

--- a/assets/js/sea/scene.js
+++ b/assets/js/sea/scene.js
@@ -7,7 +7,10 @@ const COL = {
   lime: 0xc4e600,
   limeDark: 0xa9c700,
   sea: 0x3d4fd4,
-  seaDark: 0x2f3ba8
+  seaDark: 0x2f3ba8,
+  sand: 0xe8d9a0,
+  rock: 0x7d8088,
+  palm: 0x2f8f4f
 }
 
 // A small family of fills at the same brightness/saturation as the brand's
@@ -99,29 +102,79 @@ export class SeaScene {
     this.scene.add(this.water)
   }
 
-  // Radius/height vary per island, deterministically from its path, so every
-  // sailor sees the same shape and the archipelago doesn't look uniform.
+  // One tapered hexagonal band (beach/slope/peak) with a matching ink
+  // outline nested as a child, so the outline inherits the band's transform.
+  _band(topR, botR, h, color) {
+    const geo = new THREE.CylinderGeometry(topR, botR, h, 6)
+    const mat = new THREE.MeshToonMaterial({color, gradientMap: this.gradient})
+    const mesh = new THREE.Mesh(geo, mat)
+    mesh.add(outline(geo, 1.05))
+    return mesh
+  }
+
+  // A cheap procedural palm: an ink trunk plus a squashed low-poly canopy.
+  // Positions are derived from the island's hash so every sailor sees the
+  // same trees in the same spots.
+  _palms(group, h, radius, baseY) {
+    if (!this._palmTrunkGeo) {
+      this._palmTrunkGeo = new THREE.CylinderGeometry(0.12, 0.18, 2.4)
+      this._palmLeafGeo = new THREE.IcosahedronGeometry(0.9, 0)
+    }
+    const leafMat = new THREE.MeshToonMaterial({color: COL.palm, gradientMap: this.gradient})
+    const count = 2 + (h % 3) // 2..4
+    for (let i = 0; i < count; i++) {
+      const a = ((h >> (i * 5 + 1)) % 360) * (Math.PI / 180)
+      const r = radius * (0.15 + ((h >> (i * 3 + 2)) % 40) / 100) // scattered near the shoreline
+
+      const trunk = new THREE.Mesh(this._palmTrunkGeo, new THREE.MeshBasicMaterial({color: COL.ink}))
+      trunk.position.set(Math.cos(a) * r, baseY + 1.2, Math.sin(a) * r)
+      trunk.rotation.z = Math.sin(a + i) * 0.2
+      group.add(trunk)
+
+      const leaf = new THREE.Mesh(this._palmLeafGeo, leafMat)
+      leaf.scale.set(1, 0.55, 1)
+      leaf.position.set(Math.cos(a) * r, baseY + 2.5, Math.sin(a) * r)
+      group.add(leaf)
+    }
+  }
+
+  // Islands are stacked hexagonal bands — a sand beach, a landmass slope,
+  // and a peak (rocky if the island is tall) — plus a few palms, rather than
+  // a single cone, so the silhouette reads as terrain rather than a triangle.
+  // Radius/height/tree placement are all deterministic from the island's
+  // path, so every sailor sees the same shape.
   addIsland(island) {
     const group = new THREE.Group()
     const h = hashStr(island.path)
     const radius = 5 + ((h % 100) / 100) * 5 // 5..10
     const height = 7 + (((h >> 8) % 100) / 100) * 9 // 7..16
     island.radius = radius
-    island.height = height
 
-    const geo = new THREE.ConeGeometry(radius, height, 5)
     const fill = themedColor(island.color || island.section)
-    const mat = new THREE.MeshToonMaterial({color: fill, gradientMap: this.gradient})
-    const cone = new THREE.Mesh(geo, mat)
-    cone.position.y = height / 2
-    group.add(outline(geo).translateY(height / 2))
-    group.add(cone)
+    const sandH = height * 0.16
+    const slopeH = height * 0.5
+    const peakH = height - sandH - slopeH
+    const peakFill = height > 12 ? COL.rock : fill
 
-    // A little ink post so the island reads as a marker.
-    const postGeo = new THREE.CylinderGeometry(0.25, 0.25, 6)
-    const post = new THREE.Mesh(postGeo, new THREE.MeshBasicMaterial({color: COL.ink}))
-    post.position.y = height + 3
-    group.add(post)
+    let y = 0
+    const beach = this._band(radius * 1.1, radius * 0.72, sandH, COL.sand)
+    beach.position.y = y + sandH / 2
+    group.add(beach)
+    y += sandH
+
+    const slope = this._band(radius * 0.72, radius * 0.3, slopeH, fill)
+    slope.position.y = y + slopeH / 2
+    group.add(slope)
+    y += slopeH
+
+    const peak = this._band(0, radius * 0.3, peakH, peakFill)
+    peak.position.y = y + peakH / 2
+    group.add(peak)
+    y += peakH
+
+    island.height = y // actual peak height, used to float the label above it
+
+    this._palms(group, h, radius, sandH)
 
     group.position.set(island.x, 0, island.z)
     group.userData.island = island


### PR DESCRIPTION
This PR significantly enhances the visual fidelity of islands and boats in the sea scene by replacing simple geometric primitives with more detailed, procedurally-generated structures.

## Summary
Islands are now rendered as stacked hexagonal bands (beach, slope, peak) with palm trees, instead of simple cones. Boats feature a custom canoe-shaped hull with a tapered cross-section and a curved sail, replacing basic box geometry.

## Key Changes

**Islands:**
- Replaced single cone geometry with three stacked hexagonal bands: sand beach, terrain slope, and rocky/colored peak
- Added `_band()` helper to create tapered hexagonal cylinders with ink outlines
- Implemented `_palms()` method to procedurally place 2-4 palm trees per island, with trunks and squashed icosahedron canopies
- Island height calculation now reflects actual peak position (sum of band heights)
- Added new colors to palette: sand, rock, and palm green
- Peak color changes to rock gray for taller islands (height > 12)

**Boats:**
- Implemented `_hullGeometry()` to create a custom canoe-shaped hull with:
  - Pointed bow extending ahead of the hull body
  - Tapered cross-section (narrower at keel, wider at deck)
  - Shared geometry instance across all boat instances for efficiency
- Added ink keel geometry beneath the hull
- Enhanced sail with width segments to create a wind-filled belly effect using vertex position manipulation
- Updated outline scaling to match new hull proportions

## Implementation Details
- All procedural placement (island shapes, tree positions, sail curvature) is deterministically derived from island/sailor hashes, ensuring consistent appearance across all viewers
- Geometry instances are cached (`_palmTrunkGeo`, `_palmLeafGeo`, `_hullGeo`) to avoid redundant allocations
- Vertex manipulation is used for both hull tapering and sail curvature, with `needsUpdate` and `computeVertexNormals()` calls to ensure proper rendering

https://claude.ai/code/session_01NVQxKeVqSioTEMUiXYs9ix