### PR TITLE
Fix inverted taper on island beach/slope bands

### DIFF
--- a/assets/js/sea/scene.js
+++ b/assets/js/sea/scene.js
@@ -157,12 +157,12 @@ export class SeaScene {
     const peakFill = height > 12 ? COL.rock : fill
 
     let y = 0
-    const beach = this._band(radius * 1.1, radius * 0.72, sandH, COL.sand)
+    const beach = this._band(radius * 0.72, radius * 1.1, sandH, COL.sand)
     beach.position.y = y + sandH / 2
     group.add(beach)
     y += sandH
 
-    const slope = this._band(radius * 0.72, radius * 0.3, slopeH, fill)
+    const slope = this._band(radius * 0.3, radius * 0.72, slopeH, fill)
     slope.position.y = y + slopeH / 2
     group.add(slope)
     y += slopeH


### PR DESCRIPTION
## Summary
- PR #40 (island/boat visual upgrade) merged before this fix landed, so it's a follow-up.
- `_band(topR, botR, ...)` maps straight to `CylinderGeometry(radiusTop, radiusBottom, ...)`, but the beach and slope band calls had those args swapped — those bands flared wider going up instead of tapering toward the peak, reading as an inverted vase under the (correctly tapered) peak cap.
- Swapped the args so beach → slope → peak all taper the same direction: wide base, narrow top.

## Test plan
- [ ] Load the Sea theme and confirm islands read as a tapering mound (wide beach, narrowing slope, pointed/rocky peak) instead of a flared/inverted shape.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVQxKeVqSioTEMUiXYs9ix)_