### PR TITLE
Add ambient sharks to sea mode

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -339,3 +339,9 @@ pre code.hljs {
 .sea-hint { position: absolute; top: 16px; left: 0; right: 0; text-align: center;
   font-size: 12px; letter-spacing: .06em; text-transform: uppercase;
   color: var(--color-ink-2); pointer-events: none; }
+.sea-bite { position: absolute; top: 42%; left: 50%; transform: translateX(-50%);
+  font-family: "Space Grotesk", system-ui, sans-serif; font-weight: 700;
+  font-size: clamp(14px, 2vw, 20px); text-transform: uppercase; letter-spacing: 0.03em;
+  white-space: nowrap; color: oklch(0.6 0.19 25); background: var(--color-paper);
+  border: 2px solid oklch(0.6 0.19 25); padding: 8px 16px;
+  pointer-events: none; opacity: 0; transition: opacity 150ms ease; }

--- a/assets/js/sea/index.js
+++ b/assets/js/sea/index.js
@@ -1,7 +1,16 @@
 import {SeaScene, flagTexture} from "./scene.js"
 import {createControls} from "./controls.js"
 import {SeaNet} from "./net.js"
-import {nearestDockable, nearestIsland, isCloseEnoughToDock, resolveCollision} from "./world.js"
+import {
+  nearestDockable,
+  nearestIsland,
+  isCloseEnoughToDock,
+  resolveCollision,
+  makeSharks,
+  stepShark,
+  sharkBreach,
+  nearestBitingShark
+} from "./world.js"
 import {seaBus} from "./bus.js"
 
 const MAX_SPEED = 0.6
@@ -13,6 +22,10 @@ const STATIONARY_TURN_FACTOR = 0.35 // turning while dead in the water is slower
 const CRASH_BOUNCE = -0.25 // reverses and dampens speed on collision
 const BOAT_RADIUS = 2.2 // other boats are obstacles too, not just islands
 const BOAT_COLLISION_MARGIN = 1
+const SHARK_COUNT = 5
+const SHARK_BOUNDS = 140 // sharks patrol within this radius of the harbor
+const BITE_BOUNCE = -0.6 // harder knockback than a plain crash
+const BITE_COOLDOWN = 2 // seconds of invulnerability after a bite
 
 let active = null
 
@@ -50,6 +63,12 @@ class Sea {
     this.readerBoats = new Map() // id -> {group}
     this.remoteBoats = new Map() // id -> {group}
 
+    // Sharks are ambient and purely local (see world.js) — not networked, so
+    // every visitor patrols their own and a bite only affects their own boat.
+    this.sharks = makeSharks(SHARK_COUNT, SHARK_BOUNDS)
+    this.sharkMeshes = this.sharks.map(() => this.scene.addShark())
+    this.biteCooldown = 0
+
     this.banner = document.createElement("div")
     this.banner.className = "sea-banner"
     el.appendChild(this.banner)
@@ -58,6 +77,11 @@ class Sea {
     this.hint.className = "sea-hint"
     this.hint.textContent = "Arrows / WASD to sail · Space to dock"
     el.appendChild(this.hint)
+
+    this.biteMsg = document.createElement("div")
+    this.biteMsg.className = "sea-bite"
+    this.biteMsg.textContent = "🦈 Bitten! Watch the fins."
+    el.appendChild(this.biteMsg)
 
     this.onNavigate = (e) => {
       this.pos.x = e.detail.x
@@ -106,6 +130,8 @@ class Sea {
     this.selfBoat.position.set(this.pos.x, 0, this.pos.z)
     this.selfBoat.rotation.y = this.pos.h
 
+    this.stepSharks()
+
     this.net.sendPos(
       round(this.pos.x),
       round(this.pos.z),
@@ -127,6 +153,38 @@ class Sea {
     this.scene.chase(this.pos, this.pos.h)
     this.scene.render()
     requestAnimationFrame(this.loop)
+  }
+
+  // Advances every shark's patrol/breach state and its rendered mesh, then
+  // — once any post-bite invulnerability has worn off — knocks the boat back
+  // and flashes a warning if it strayed within range of one.
+  stepSharks() {
+    for (let i = 0; i < this.sharks.length; i++) {
+      const shark = this.sharks[i]
+      stepShark(shark, 0.016, SHARK_BOUNDS)
+      this.scene.updateShark(this.sharkMeshes[i], shark, sharkBreach(shark))
+    }
+
+    if (this.biteCooldown > 0) {
+      this.biteCooldown -= 0.016
+      return
+    }
+    const shark = nearestBitingShark(this.pos.x, this.pos.z, this.sharks)
+    if (!shark) return
+
+    this.biteCooldown = BITE_COOLDOWN
+    this.speed *= BITE_BOUNCE
+    const dx = this.pos.x - shark.x
+    const dz = this.pos.z - shark.z
+    const d = Math.hypot(dx, dz) || 0.001
+    this.pos.x += (dx / d) * 4
+    this.pos.z += (dz / d) * 4
+
+    this.biteMsg.style.opacity = "1"
+    clearTimeout(this._biteMsgTimer)
+    this._biteMsgTimer = setTimeout(() => {
+      this.biteMsg.style.opacity = "0"
+    }, 1200)
   }
 
   // Live sailors (from net.remote). A sailor id that is also in the roster is
@@ -270,8 +328,10 @@ class Sea {
     this.net.destroy()
     this.scene.dispose()
     seaBus.removeEventListener("sea:navigate", this.onNavigate)
+    clearTimeout(this._biteMsgTimer)
     if (this.banner.parentNode) this.banner.remove()
     if (this.hint.parentNode) this.hint.remove()
+    if (this.biteMsg.parentNode) this.biteMsg.remove()
   }
 }
 

--- a/assets/js/sea/scene.js
+++ b/assets/js/sea/scene.js
@@ -10,7 +10,8 @@ const COL = {
   seaDark: 0x2f3ba8,
   sand: 0xe8d9a0,
   rock: 0x7d8088,
-  palm: 0x2f8f4f
+  palm: 0x2f8f4f,
+  shark: 0x5b6470
 }
 
 // A small family of fills at the same brightness/saturation as the brand's
@@ -288,6 +289,60 @@ export class SeaScene {
 
   removeBoat(group) {
     this.scene.remove(group)
+  }
+
+  // A single raked fin blade: a thin triangle (root-to-root along the base,
+  // swept tip above) extruded for thickness. Local origin is the *front*
+  // root, extending backward (-z) and up (+y) from there, so callers place
+  // it by setting `position` to where the front of the fin meets the body.
+  _finBlade(len, height, thickness, color = COL.ink) {
+    const shape = new THREE.Shape()
+    shape.moveTo(0, 0)
+    shape.lineTo(len, 0)
+    shape.lineTo(len * 0.45, height)
+    shape.closePath()
+
+    const geo = new THREE.ExtrudeGeometry(shape, {depth: thickness, bevelEnabled: false})
+    geo.rotateY(Math.PI / 2) // shape drawn as a side profile; swing it to face forward
+    geo.translate(-thickness / 2, 0, 0) // center the blade's thickness
+    return new THREE.Mesh(geo, new THREE.MeshBasicMaterial({color}))
+  }
+
+  // Shark: a stretched low-poly body (mostly submerged) plus a dorsal and
+  // tail fin. Ambient and purely local — see world.js's shark helpers for
+  // the patrol/breach simulation this just renders each frame.
+  addShark() {
+    const group = new THREE.Group()
+
+    const bodyGeo = new THREE.IcosahedronGeometry(1, 1)
+    const body = new THREE.Mesh(
+      bodyGeo,
+      new THREE.MeshToonMaterial({color: COL.shark, gradientMap: this.gradient})
+    )
+    body.scale.set(0.85, 0.6, 2.4)
+    body.position.y = -0.55 // mostly underwater; only the topmost sliver breaks the surface
+    body.add(outline(bodyGeo, 1.08))
+    group.add(body)
+
+    const dorsal = this._finBlade(1.3, 1.3, 0.14)
+    dorsal.position.set(0, 0, 0.4)
+    group.add(dorsal)
+
+    const tail = this._finBlade(0.8, 1.0, 0.12)
+    tail.position.set(0, 0, -2.1)
+    group.add(tail)
+
+    this.scene.add(group)
+    return group
+  }
+
+  // Applies one frame of a shark's simulated state (see world.js) to its
+  // rendered group: patrol position/heading, plus lifting clear of the
+  // water and pitching its nose up while `breach` (0..1) is non-zero.
+  updateShark(group, shark, breach) {
+    group.position.set(shark.x, breach * 3.2, shark.z)
+    group.rotation.y = shark.h
+    group.rotation.x = -breach * 0.4
   }
 
   // Cheap animated swell.

--- a/assets/js/sea/world.js
+++ b/assets/js/sea/world.js
@@ -74,3 +74,66 @@ export function resolveCollision(x, z, islands, margin = COLLISION_MARGIN) {
   }
   return {x, z, hit}
 }
+
+// Sharks are ambient and purely local — every visitor simulates their own,
+// unsynced, so there's no server/channel cost to them. They wander with a
+// gentle random turn bias and periodically breach.
+const SHARK_SPEED = 0.16
+const SHARK_JUMP_MIN = 4 // seconds of patrol before the next jump, at least
+const SHARK_JUMP_MAX = 10
+const SHARK_JUMP_DURATION = 1.2 // seconds a breach takes, up and back down
+const SHARK_BITE_RADIUS = 3.2
+
+export function makeSharks(count, bounds, rand = Math.random) {
+  const sharks = []
+  for (let i = 0; i < count; i++) {
+    sharks.push({
+      x: (rand() - 0.5) * bounds * 2,
+      z: (rand() - 0.5) * bounds * 2,
+      h: rand() * Math.PI * 2,
+      turnBias: (rand() - 0.5) * 0.012,
+      jumpIn: SHARK_JUMP_MIN + rand() * (SHARK_JUMP_MAX - SHARK_JUMP_MIN),
+      jumpT: 0 // > 0 while mid-breach; counts down from SHARK_JUMP_DURATION
+    })
+  }
+  return sharks
+}
+
+// Advances one shark's patrol/breach state by dt seconds, wandering within
+// `bounds` of the harbor (turns back inward once it strays past the edge).
+export function stepShark(shark, dt, bounds, rand = Math.random) {
+  shark.h += shark.turnBias + (rand() - 0.5) * 0.01
+  shark.x += Math.sin(shark.h) * SHARK_SPEED
+  shark.z += Math.cos(shark.h) * SHARK_SPEED
+  if (Math.hypot(shark.x, shark.z) > bounds) shark.h += Math.PI
+
+  if (shark.jumpT > 0) {
+    shark.jumpT -= dt
+    if (shark.jumpT <= 0) {
+      shark.jumpT = 0
+      shark.jumpIn = SHARK_JUMP_MIN + rand() * (SHARK_JUMP_MAX - SHARK_JUMP_MIN)
+    }
+  } else {
+    shark.jumpIn -= dt
+    if (shark.jumpIn <= 0) shark.jumpT = SHARK_JUMP_DURATION
+  }
+}
+
+// 0 (submerged, fin only) .. 1 (fully breached) for the shark's current
+// instant — a simple arc up and back down over the breach's duration, 0 the
+// rest of the time.
+export function sharkBreach(shark) {
+  if (shark.jumpT <= 0) return 0
+  const p = 1 - shark.jumpT / SHARK_JUMP_DURATION
+  return Math.sin(p * Math.PI)
+}
+
+// The first shark within bite range of (x, z), or null. Bounds a shark's
+// hitbox to its own radius regardless of how deep the caller wants to go
+// with a cooldown on top (that's the caller's concern, not this check's).
+export function nearestBitingShark(x, z, sharks, radius = SHARK_BITE_RADIUS) {
+  for (const shark of sharks) {
+    if (Math.hypot(shark.x - x, shark.z - z) < radius) return shark
+  }
+  return null
+}


### PR DESCRIPTION
## Summary
- Sharks patrol the archipelago with just a dorsal fin visible above the water, and periodically breach into a full jump (arcing clear of the surface, nose pitching up) on a random per-shark timer.
- Sailing within bite range knocks the boat back hard and flashes a warning message, with a short invulnerability cooldown so one encounter doesn't chain-bite.
- Sharks are purely client-side/ambient (`world.js`'s `makeSharks`/`stepShark`/`sharkBreach`/`nearestBitingShark`) — not networked — so every visitor sees their own patrol and a bite only affects their own boat. No new server/channel cost.
- Shark body, dorsal fin, and tail fin are all procedural three.js geometry (stretched low-poly icosahedron body + extruded fin blades), built with the same technique as the boat hull from the earlier island/boat visual upgrade — no external models.

## Test plan
- [ ] Enter Sea mode and confirm shark fins are visible, roaming the water.
- [ ] Watch for a shark to breach (jumps clear of the water on its own timer).
- [ ] Sail the boat into a shark and confirm the knockback + "Bitten!" warning appear, and that it doesn't re-trigger every frame while still nearby.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVQxKeVqSioTEMUiXYs9ix)_