### PR TITLE
Blunt the island peak instead of a sharp point

### DIFF
--- a/assets/js/sea/scene.js
+++ b/assets/js/sea/scene.js
@@ -168,7 +168,7 @@ export class SeaScene {
     group.add(slope)
     y += slopeH
 
-    const peak = this._band(0, radius * 0.3, peakH, peakFill)
+    const peak = this._band(radius * 0.12, radius * 0.3, peakH, peakFill)
     peak.position.y = y + peakH / 2
     group.add(peak)
     y += peakH


### PR DESCRIPTION
## Summary
- The peak band of each island tapered to a 0-radius apex (`_band(0, radius * 0.3, ...)`), giving islands a spiky top.
- Give the peak a small flat top radius (`radius * 0.12`) instead, same as the beach/slope bands below it, so the summit reads as blunt/truncated rather than pointy.

## Test plan
- [ ] Load the Sea theme and confirm island peaks now have a small flat top instead of coming to a sharp point.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVQxKeVqSioTEMUiXYs9ix)_