### PR TITLE
Add health check endpoint

### DIFF
--- a/lib/blog_web/controllers/health_controller.ex
+++ b/lib/blog_web/controllers/health_controller.ex
@@ -1,0 +1,7 @@
+defmodule BlogWeb.HealthController do
+  use BlogWeb, :controller
+
+  def show(conn, _params) do
+    json(conn, %{status: "ok"})
+  end
+end

--- a/lib/blog_web/router.ex
+++ b/lib/blog_web/router.ex
@@ -20,6 +20,10 @@ defmodule BlogWeb.Router do
   end
 
   scope "/", BlogWeb do
+    get("/healthz", HealthController, :show)
+  end
+
+  scope "/", BlogWeb do
     pipe_through(:browser)
 
     live_session :public,

--- a/test/blog_web/controllers/health_controller_test.exs
+++ b/test/blog_web/controllers/health_controller_test.exs
@@ -1,0 +1,8 @@
+defmodule BlogWeb.HealthControllerTest do
+  use BlogWeb.ConnCase, async: true
+
+  test "GET /healthz returns ok status", %{conn: conn} do
+    conn = get(conn, ~p"/healthz")
+    assert json_response(conn, 200) == %{"status" => "ok"}
+  end
+end


### PR DESCRIPTION
## Summary
This PR adds a health check endpoint to the application that returns a simple status response.

## Changes
- **New HealthController**: Created `BlogWeb.HealthController` with a `show/2` action that returns a JSON response with `{"status": "ok"}`
- **Router configuration**: Added a new scope in `BlogWeb.Router` that maps `GET /healthz` to the health controller's show action
- **Test coverage**: Added comprehensive test in `BlogWeb.HealthControllerTest` that verifies the endpoint returns a 200 status code with the expected JSON response

## Implementation Details
- The health check endpoint is intentionally placed outside the browser pipeline, making it accessible without browser-specific middleware
- The endpoint returns a simple JSON response suitable for monitoring and load balancer health checks
- The implementation follows standard Phoenix conventions for controllers and routing

https://claude.ai/code/session_01UCLFe1FM4XSkXkssACvF5t