### PR TITLE
Track page views/events in DuckDB, with an admin analytics dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,9 +20,10 @@ node_modules/
 *.db-shm
 *.db-wal
 
-# DuckDB dev analytics database
+# DuckDB dev analytics database, and its downloaded extensions cache
 *.duckdb
 *.duckdb.wal
+/duckdb_extensions/
 
 # Env files
 .env

--- a/lib/blog/analytics.ex
+++ b/lib/blog/analytics.ex
@@ -111,7 +111,7 @@ defmodule Blog.Analytics do
 
     schedule_flush()
 
-    {:ok, %{conn: conn, db: db, avg_supported?: ensure_core_functions(conn), buffer: []}}
+    {:ok, %{conn: conn, db: db, avg_supported?: ensure_core_functions(conn, path), buffer: []}}
   end
 
   @impl true
@@ -122,11 +122,25 @@ defmodule Blog.Analytics do
 
   # `SUM`/`AVG` live in DuckDB's `core_functions` extension, which this
   # precompiled build doesn't bundle. Installing it needs network access
-  # (once cached to disk, later boots reuse the cached copy); if that fails
-  # -- offline, read-only filesystem, whatever -- reporting just falls back
-  # to reporting the average as unavailable instead of crashing the app.
-  defp ensure_core_functions(conn) do
-    with {:ok, _} <- Duckdbex.query(conn, "INSTALL core_functions"),
+  # (once cached to disk, later boots reuse the cached copy) *and* a
+  # writable directory to cache it in -- DuckDB defaults to one under
+  # $HOME, which in the deployed container is the `nobody` user's
+  # `/nonexistent`, so that's pointed explicitly at a directory next to the
+  # analytics file itself (on the same persistent volume, so the download
+  # survives restarts). If any of this fails -- offline, read-only
+  # filesystem, whatever -- reporting just falls back to reporting the
+  # average as unavailable instead of crashing the app.
+  defp ensure_core_functions(conn, path) do
+    extension_dir = extension_directory(path)
+    File.mkdir_p!(extension_dir)
+    escaped_dir = String.replace(extension_dir, "'", "''")
+
+    # SET doesn't go through the regular prepared-statement parameter path
+    # (binding $1 here fails with "value not provided"), so this has to be
+    # interpolated -- safe since extension_dir only ever comes from our own
+    # config (ANALYTICS_PATH / the default), never user input.
+    with {:ok, _} <- Duckdbex.query(conn, "SET extension_directory = '#{escaped_dir}'"),
+         {:ok, _} <- Duckdbex.query(conn, "INSTALL core_functions"),
          {:ok, _} <- Duckdbex.query(conn, "LOAD core_functions") do
       true
     else
@@ -139,6 +153,12 @@ defmodule Blog.Analytics do
         false
     end
   end
+
+  defp extension_directory(:memory) do
+    Path.join(System.tmp_dir!(), "blog_analytics_duckdb_extensions")
+  end
+
+  defp extension_directory(path), do: Path.join(Path.dirname(path), "duckdb_extensions")
 
   @impl true
   def handle_cast({:track, event_name, attrs}, state) do


### PR DESCRIPTION
## Summary
- Adds `Blog.Analytics`, a GenServer around a DuckDB file on the same backed-up `/data` volume as the SQLite database (`ANALYTICS_PATH`, defaulting next to `DATABASE_PATH`). `Blog.Analytics.track/2` records arbitrary named events with a path/referrer/session_id/country plus a free-form JSON `props` map, so page views are just the first event wired up — other interactions can call the same function later.
- Page views are tracked automatically via `BlogWeb.AnalyticsTracker`, an `on_mount` hook (mirroring the existing `PresenceTracker`) attached to every public LiveView route, keyed by the client-supplied `sailor_id` already used for presence/the Sea easter egg.
- `Blog.Analytics.stats/3` aggregates page views, sessions, top pages (with average time-on-page from the gap to each session's next view), top countries, and top referrers (normalized to a bare host) entirely in SQL. `BlogWeb.Admin.AnalyticsLive` (`/admin/analytics`) renders this with a time-range and referrer-substring filter, both reflected in the URL.
- `track/2` buffers events in memory instead of writing on every call; a background GenServer flushes the buffer to DuckDB in one bulk write (via DuckDB's Appender) every 5s, once it hits 200 events, or on an explicit `flush/0` — which `stats/3` calls automatically, so the dashboard is always current even though writes lag by a few seconds. Buffered events also flush on GenServer shutdown so a deploy doesn't drop the last batch.
- Works around a real constraint of the precompiled DuckDB build this depends on: it ships without the `core_functions` extension, so `SUM`/`AVG`/`now()` aren't in the catalog until that extension is installed. Timestamps are stored as plain epoch-microsecond integers to avoid needing any date functions at all, and the extension is installed/loaded once at boot (with its cache directory pointed at `duckdb_extensions/` next to the analytics file, since DuckDB's default under `$HOME` doesn't exist for the `nobody` user in the prod container) — falling back to reporting the average as unavailable, rather than crashing, if that can't be loaded.

## Test plan
- [x] `mix compile --warnings-as-errors` is clean
- [x] `mix test` passes (87 tests), including new coverage for buffering/auto-flush behavior and `stats/3` aggregation
- [x] Manually verified end-to-end against the dev server with a real browser: page views, referrer/country breakdown, and duration show up correctly on `/admin/analytics`, and the filter form correctly re-queries via URL params
- [x] Verified `avg_supported?` resolves `true` through the real boot path after the extension-directory fix

---
🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_011qg69nx2vbrZMBRViA3QJ4

---
_Generated by [Claude Code](https://claude.ai/code/session_011qg69nx2vbrZMBRViA3QJ4)_