### PR TITLE
Add analytics live view tests and improve form testability

### DIFF
--- a/lib/blog_web/live/admin/analytics_live.ex
+++ b/lib/blog_web/live/admin/analytics_live.ex
@@ -114,7 +114,7 @@ defmodule BlogWeb.Admin.AnalyticsLive do
           </div>
         </div>
 
-        <form phx-change="filter" class="mb-8 flex flex-wrap items-end gap-4">
+        <form id="analytics-filter" phx-change="filter" class="mb-8 flex flex-wrap items-end gap-4">
           <.input
             type="select"
             name="range"

--- a/test/blog_web/live/admin/analytics_live_test.exs
+++ b/test/blog_web/live/admin/analytics_live_test.exs
@@ -1,0 +1,53 @@
+defmodule BlogWeb.Admin.AnalyticsLiveTest do
+  use BlogWeb.ConnCase, async: false
+  import Phoenix.LiveViewTest
+
+  alias Blog.Analytics
+
+  defp admin_conn(conn) do
+    conn
+    |> Phoenix.ConnTest.init_test_session(%{})
+    |> Plug.Conn.put_session(:admin_authenticated, true)
+  end
+
+  test "GET /admin/analytics redirects to login when not authenticated", %{conn: conn} do
+    assert {:error, {:redirect, %{to: "/admin/login"}}} = live(conn, ~p"/admin/analytics")
+  end
+
+  test "changing the range filter re-queries and shows different stats", %{conn: conn} do
+    now = DateTime.utc_now()
+    old = DateTime.add(now, -60, :day)
+
+    Analytics.track("page_view", %{path: "/recent-page", session_id: "recent-sess"})
+    :ok = Analytics.flush()
+
+    {:ok, _cols, _rows} =
+      Analytics.query(
+        "INSERT INTO events (occurred_at_us, event_name, path, session_id) VALUES ($1, 'page_view', '/old-page', 'old-sess')",
+        [DateTime.to_unix(old, :microsecond)]
+      )
+
+    {:ok, view, html} = live(admin_conn(conn), ~p"/admin/analytics?range=7d")
+
+    assert html =~ "/recent-page"
+    refute html =~ "/old-page"
+
+    html_all =
+      view
+      |> form("form", %{"range" => "all", "referrer" => ""})
+      |> render_change()
+
+    assert html_all =~ "/recent-page"
+    assert html_all =~ "/old-page"
+  end
+
+  test "the range filter is reflected in the URL via push_patch", %{conn: conn} do
+    {:ok, view, _html} = live(admin_conn(conn), ~p"/admin/analytics?range=7d")
+
+    view
+    |> form("form", %{"range" => "30d", "referrer" => ""})
+    |> render_change()
+
+    assert_patch(view, ~p"/admin/analytics?#{%{range: "30d", referrer: ""}}")
+  end
+end


### PR DESCRIPTION
## Summary
This PR adds comprehensive test coverage for the admin analytics live view and makes a small improvement to form testability by adding an ID to the analytics filter form.

## Key Changes
- **New test file**: `test/blog_web/live/admin/analytics_live_test.exs` with three test cases:
  - Authentication check: Verifies that unauthenticated users are redirected to login
  - Range filter functionality: Tests that changing the date range filter re-queries analytics data and displays different results
  - URL state management: Confirms that range filter changes are reflected in the URL via `push_patch`
- **Form improvement**: Added `id="analytics-filter"` to the analytics filter form to enable easier form selection in tests

## Implementation Details
- Tests use `admin_conn/1` helper to set up authenticated admin sessions
- Analytics data is inserted directly into the database to test filtering across different time ranges (recent vs. 60 days old)
- Tests verify both the rendered HTML output and URL state changes when filters are applied

https://claude.ai/code/session_01N7qe9bT6t1LDJHWfqkV16f