### PR TITLE
Exclude admin's own visits from analytics; add click-to-filter

### DIFF
--- a/lib/blog/analytics.ex
+++ b/lib/blog/analytics.ex
@@ -68,6 +68,11 @@ defmodule Blog.Analytics do
 
     * `:referrer_contains` - only count views whose referrer host contains
       this substring (case-insensitive), e.g. `"google"`
+    * `:direct` - if truthy, only count views with no referrer at all
+      (takes precedence over `:referrer_contains`)
+    * `:path` - only count views of this exact path
+    * `:country` - only count views from this exact country code, or
+      `"Unknown"` for views with no resolved country
     * `:limit` - max rows per breakdown list (default 20)
 
   `source` in `top_referrers` is a bare host (`"google.com"`, `"Direct"`
@@ -184,8 +189,8 @@ defmodule Blog.Analytics do
   def handle_call({:stats, from, to, opts}, _from, state) do
     state = flush_buffer(state)
     limit = Keyword.get(opts, :limit, 20)
-    where_sql = ctes(where_clause(opts[:referrer_contains]))
-    params = where_params(from, to, opts[:referrer_contains])
+    {filter_sql, params} = where_clause_and_params(from, to, opts)
+    where_sql = ctes(filter_sql)
     avg_expr = if state.avg_supported?, do: "AVG(duration_us)", else: "NULL"
 
     reply =
@@ -224,20 +229,53 @@ defmodule Blog.Analytics do
     {:reply, :ok, flush_buffer(state)}
   end
 
-  defp where_clause(nil), do: ""
-  defp where_clause(""), do: ""
-  defp where_clause(_referrer_contains), do: " AND referrer_host LIKE $4"
+  # Builds the `AND ...` fragment (with `$4`, `$5`, ... placeholders) and its
+  # matching params list together, so the SQL and the bindings can never
+  # drift out of sync the way keeping them in two separate functions risked.
+  defp where_clause_and_params(from, to, opts) do
+    base_params = [
+      @page_view_event,
+      DateTime.to_unix(from, :microsecond),
+      DateTime.to_unix(to, :microsecond)
+    ]
 
-  defp where_params(from, to, nil), do: base_where_params(from, to)
-  defp where_params(from, to, ""), do: base_where_params(from, to)
+    [referrer_filter(opts), path_filter(opts[:path]), country_filter(opts[:country])]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.reduce({"", base_params}, fn
+      {template, :no_param}, {sql, params} ->
+        {sql <> " AND " <> template, params}
 
-  defp where_params(from, to, referrer_contains) do
-    base_where_params(from, to) ++ ["%" <> String.downcase(referrer_contains) <> "%"]
+      {template, value}, {sql, params} ->
+        placeholder = "$#{length(params) + 1}"
+        {sql <> " AND " <> String.replace(template, "?", placeholder), params ++ [value]}
+    end)
   end
 
-  defp base_where_params(from, to) do
-    [@page_view_event, DateTime.to_unix(from, :microsecond), DateTime.to_unix(to, :microsecond)]
+  defp referrer_filter(opts) do
+    cond do
+      opts[:direct] ->
+        {"referrer_host IS NULL", :no_param}
+
+      present?(opts[:referrer_contains]) ->
+        {"referrer_host LIKE ?", "%" <> String.downcase(opts[:referrer_contains]) <> "%"}
+
+      true ->
+        nil
+    end
   end
+
+  defp path_filter(nil), do: nil
+  defp path_filter(""), do: nil
+  defp path_filter(path), do: {"path = ?", path}
+
+  defp country_filter(nil), do: nil
+  defp country_filter(""), do: nil
+  defp country_filter("Unknown"), do: {"country IS NULL", :no_param}
+  defp country_filter(country), do: {"country = ?", country}
+
+  defp present?(nil), do: false
+  defp present?(""), do: false
+  defp present?(_value), do: true
 
   defp ctes(referrer_filter_sql) do
     """

--- a/lib/blog_web/controllers/admin_session_controller.ex
+++ b/lib/blog_web/controllers/admin_session_controller.ex
@@ -9,6 +9,12 @@ defmodule BlogWeb.AdminSessionController do
     if BlogWeb.AdminAuth.valid_password?(password) do
       conn
       |> put_session(:admin_authenticated, true)
+      # Never cleared, including on logout (see `delete/2` below) -- this is
+      # the durable "this browser is the admin" marker that
+      # `BlogWeb.AnalyticsTracker` checks to exclude the admin's own
+      # visits from analytics, regardless of whether they're currently
+      # logged in.
+      |> put_session(:admin_seen, true)
       |> configure_session(renew: true)
       |> redirect(to: ~p"/admin")
     else
@@ -20,7 +26,7 @@ defmodule BlogWeb.AdminSessionController do
 
   def delete(conn, _params) do
     conn
-    |> configure_session(drop: true)
+    |> delete_session(:admin_authenticated)
     |> redirect(to: ~p"/")
   end
 end

--- a/lib/blog_web/endpoint.ex
+++ b/lib/blog_web/endpoint.ex
@@ -7,7 +7,12 @@ defmodule BlogWeb.Endpoint do
     store: :cookie,
     key: "_blog_key",
     signing_salt: "blogSessSalt",
-    same_site: "Lax"
+    same_site: "Lax",
+    # Long-lived on purpose: `:admin_seen` (see AdminSessionController) rides
+    # in this same cookie and needs to survive browser restarts so analytics
+    # can keep excluding the admin's own traffic indefinitely, not just for
+    # the current session.
+    max_age: 60 * 60 * 24 * 365 * 5
   ]
 
   socket("/live", Phoenix.LiveView.Socket,

--- a/lib/blog_web/live/admin/analytics_live.ex
+++ b/lib/blog_web/live/admin/analytics_live.ex
@@ -11,6 +11,11 @@ defmodule BlogWeb.Admin.AnalyticsLive do
     {"all", "All time", nil}
   ]
 
+  # Sentinel written into the `referrer` query param when a "Direct" row is
+  # clicked, since "no referrer" can't be expressed as a substring to search
+  # for the way a real host can.
+  @direct_referrer "direct"
+
   @impl true
   def mount(_params, _session, socket) do
     {:ok, assign(socket, page_title: "Analytics")}
@@ -23,23 +28,67 @@ defmodule BlogWeb.Admin.AnalyticsLive do
         do: params["range"],
         else: "7d"
 
-    referrer_filter = params["referrer"] || ""
-
     {:noreply,
      socket
-     |> assign(range: range, referrer_filter: referrer_filter, ranges: @ranges)
+     |> assign(
+       range: range,
+       referrer_filter: params["referrer"] || "",
+       path_filter: params["path"] || "",
+       country_filter: params["country"] || "",
+       ranges: @ranges
+     )
      |> load_report()}
   end
 
+  # The range/referrer form -- text-box driven, so it only knows about its
+  # own two fields and relies on us to carry the click-driven filters along.
   @impl true
   def handle_event("filter", %{"range" => range, "referrer" => referrer}, socket) do
+    {:noreply, push_patch(socket, to: filter_path(socket, %{range: range, referrer: referrer}))}
+  end
+
+  # Clicking a row in one of the breakdown lists turns it into a filter.
+  def handle_event("set_filter", %{"field" => field, "value" => value}, socket) do
+    {:noreply, push_patch(socket, to: filter_path(socket, %{filter_key(field) => value}))}
+  end
+
+  def handle_event("clear_filter", %{"field" => field}, socket) do
+    {:noreply, push_patch(socket, to: filter_path(socket, %{filter_key(field) => ""}))}
+  end
+
+  def handle_event("reset_filters", _params, socket) do
     {:noreply,
-     push_patch(socket, to: ~p"/admin/analytics?#{%{range: range, referrer: referrer}}")}
+     push_patch(socket, to: filter_path(socket, %{path: "", country: "", referrer: ""}))}
+  end
+
+  defp filter_key("path"), do: :path
+  defp filter_key("country"), do: :country
+  defp filter_key("referrer"), do: :referrer
+
+  # Builds the analytics URL for the current filter state, overridden with
+  # whatever the triggering event changed -- so e.g. clicking a country
+  # keeps whatever path/referrer filter was already active.
+  defp filter_path(socket, overrides) do
+    params =
+      %{
+        range: socket.assigns.range,
+        referrer: socket.assigns.referrer_filter,
+        path: socket.assigns.path_filter,
+        country: socket.assigns.country_filter
+      }
+      |> Map.merge(overrides)
+
+    ~p"/admin/analytics?#{params}"
   end
 
   defp load_report(socket) do
     {from, to} = range_bounds(socket.assigns.range)
-    opts = [referrer_contains: blank_to_nil(socket.assigns.referrer_filter)]
+
+    opts =
+      [
+        path: blank_to_nil(socket.assigns.path_filter),
+        country: blank_to_nil(socket.assigns.country_filter)
+      ] ++ referrer_opts(socket.assigns.referrer_filter)
 
     case Analytics.stats(from, to, opts) do
       {:ok, report} ->
@@ -60,8 +109,23 @@ defmodule BlogWeb.Admin.AnalyticsLive do
     end
   end
 
+  defp referrer_opts(@direct_referrer), do: [direct: true]
+  defp referrer_opts(value), do: [referrer_contains: blank_to_nil(value)]
+
   defp blank_to_nil(""), do: nil
   defp blank_to_nil(value), do: value
+
+  defp any_filters?(assigns) do
+    assigns.path_filter != "" or assigns.country_filter != "" or assigns.referrer_filter != ""
+  end
+
+  # What a clicked "Top referrers" row should filter by: the sentinel for
+  # "Direct", the host itself otherwise.
+  defp referrer_filter_value("Direct"), do: @direct_referrer
+  defp referrer_filter_value(source), do: source
+
+  defp referrer_filter_label(@direct_referrer), do: "Direct"
+  defp referrer_filter_label(value), do: value
 
   defp range_bounds(range) do
     now = DateTime.utc_now()
@@ -114,7 +178,7 @@ defmodule BlogWeb.Admin.AnalyticsLive do
           </div>
         </div>
 
-        <form id="analytics-filter" phx-change="filter" class="mb-8 flex flex-wrap items-end gap-4">
+        <form id="analytics-filter" phx-change="filter" class="mb-4 flex flex-wrap items-end gap-4">
           <.input
             type="select"
             name="range"
@@ -130,6 +194,44 @@ defmodule BlogWeb.Admin.AnalyticsLive do
             placeholder="e.g. google"
           />
         </form>
+
+        <div :if={any_filters?(assigns)} class="mb-8 flex flex-wrap items-center gap-2">
+          <span class="label">Filtered by</span>
+          <button
+            :if={@path_filter != ""}
+            type="button"
+            phx-click="clear_filter"
+            phx-value-field="path"
+            class="mark text-[12px]"
+          >
+            Path: {@path_filter} &times;
+          </button>
+          <button
+            :if={@country_filter != ""}
+            type="button"
+            phx-click="clear_filter"
+            phx-value-field="country"
+            class="mark text-[12px]"
+          >
+            Country: {@country_filter} &times;
+          </button>
+          <button
+            :if={@referrer_filter != ""}
+            type="button"
+            phx-click="clear_filter"
+            phx-value-field="referrer"
+            class="mark text-[12px]"
+          >
+            Referrer: {referrer_filter_label(@referrer_filter)} &times;
+          </button>
+          <button
+            type="button"
+            phx-click="reset_filters"
+            class="text-[13px] text-ink-2 !shadow-[inset_0_-1px_0_var(--color-rule)] hover:!text-ink"
+          >
+            Reset
+          </button>
+        </div>
 
         <div class="mb-10 grid grid-cols-3 gap-4 border-y border-ink py-6 text-center">
           <div>
@@ -153,12 +255,22 @@ defmodule BlogWeb.Admin.AnalyticsLive do
             <h2 class="label mb-3">Top pages</h2>
             <div :if={@top_paths == []} class="text-[13px] text-ink-3">No page views yet.</div>
             <div class="divide-y divide-rule border-t border-ink">
-              <div :for={row <- @top_paths} class="flex items-center justify-between gap-4 py-2.5">
+              <button
+                :for={row <- @top_paths}
+                type="button"
+                phx-click="set_filter"
+                phx-value-field="path"
+                phx-value-value={row.path}
+                class={[
+                  "flex w-full items-center justify-between gap-4 py-2.5 text-left hover:bg-paper-2",
+                  @path_filter == row.path && "bg-paper-2"
+                ]}
+              >
                 <span class="truncate text-[13px] text-ink">{row.path}</span>
                 <span class="shrink-0 text-[13px] text-ink-2">
                   {row.views} views &middot; {format_duration(row.avg_duration_seconds)}
                 </span>
-              </div>
+              </button>
             </div>
           </section>
 
@@ -166,10 +278,20 @@ defmodule BlogWeb.Admin.AnalyticsLive do
             <h2 class="label mb-3">Top countries</h2>
             <div :if={@top_countries == []} class="text-[13px] text-ink-3">No page views yet.</div>
             <div class="divide-y divide-rule border-t border-ink">
-              <div :for={row <- @top_countries} class="flex items-center justify-between gap-4 py-2.5">
+              <button
+                :for={row <- @top_countries}
+                type="button"
+                phx-click="set_filter"
+                phx-value-field="country"
+                phx-value-value={row.country}
+                class={[
+                  "flex w-full items-center justify-between gap-4 py-2.5 text-left hover:bg-paper-2",
+                  @country_filter == row.country && "bg-paper-2"
+                ]}
+              >
                 <span class="text-[13px] text-ink">{flag(row.country)} {row.country}</span>
                 <span class="shrink-0 text-[13px] text-ink-2">{row.sessions} sessions</span>
-              </div>
+              </button>
             </div>
           </section>
 
@@ -177,10 +299,20 @@ defmodule BlogWeb.Admin.AnalyticsLive do
             <h2 class="label mb-3">Top referrers</h2>
             <div :if={@top_referrers == []} class="text-[13px] text-ink-3">No page views yet.</div>
             <div class="divide-y divide-rule border-t border-ink">
-              <div :for={row <- @top_referrers} class="flex items-center justify-between gap-4 py-2.5">
+              <button
+                :for={row <- @top_referrers}
+                type="button"
+                phx-click="set_filter"
+                phx-value-field="referrer"
+                phx-value-value={referrer_filter_value(row.source)}
+                class={[
+                  "flex w-full items-center justify-between gap-4 py-2.5 text-left hover:bg-paper-2",
+                  @referrer_filter == referrer_filter_value(row.source) && "bg-paper-2"
+                ]}
+              >
                 <span class="text-[13px] text-ink">{row.source}</span>
                 <span class="shrink-0 text-[13px] text-ink-2">{row.sessions} sessions</span>
-              </div>
+              </button>
             </div>
           </section>
         </div>

--- a/lib/blog_web/live/admin/analytics_live.ex
+++ b/lib/blog_web/live/admin/analytics_live.ex
@@ -86,6 +86,10 @@ defmodule BlogWeb.Admin.AnalyticsLive do
 
     opts =
       [
+        # Higher than Blog.Analytics's own default of 20: with click-to-filter
+        # now inviting more distinct paths/countries/referrers into view, a
+        # tighter cap made rows quietly disappear off the bottom of the list.
+        limit: 50,
         path: blank_to_nil(socket.assigns.path_filter),
         country: blank_to_nil(socket.assigns.country_filter)
       ] ++ referrer_opts(socket.assigns.referrer_filter)

--- a/lib/blog_web/live/analytics_tracker.ex
+++ b/lib/blog_web/live/analytics_tracker.ex
@@ -4,13 +4,18 @@ defmodule BlogWeb.AnalyticsTracker do
   each connected LiveView mount and subsequent navigation, keyed by the
   client-supplied `sailor_id` (see `BlogWeb.PresenceTracker`) so views from
   the same browser tab can be correlated without cookies.
+
+  Skips tracking entirely for any browser that has ever logged in as admin
+  (`session["admin_seen"]`, set by `BlogWeb.AdminSessionController` and
+  never cleared -- see that module), so the admin's own visits never
+  pollute their own analytics.
   """
 
   import Phoenix.LiveView
   import Phoenix.Component, only: [assign: 3]
 
-  def on_mount(:track, _params, _session, socket) do
-    if connected?(socket) do
+  def on_mount(:track, _params, session, socket) do
+    if connected?(socket) and !session["admin_seen"] do
       connect_params = get_connect_params(socket)
 
       socket =

--- a/test/blog/analytics_test.exs
+++ b/test/blog/analytics_test.exs
@@ -178,6 +178,83 @@ defmodule Blog.AnalyticsTest do
       assert "/filtered-a" in paths
       refute "/filtered-b" in paths
     end
+
+    test "direct: true filters to views with no referrer at all" do
+      session_google = "sess_#{System.unique_integer([:positive])}"
+      session_direct = "sess_#{System.unique_integer([:positive])}"
+      base = unique_base()
+
+      insert_page_view(session_google, "/direct-a", "US", "https://google.com/search", base)
+      insert_page_view(session_direct, "/direct-b", "US", nil, base)
+
+      {:ok, report} =
+        Analytics.stats(DateTime.add(base, -1, :minute), DateTime.add(base, 1, :minute),
+          direct: true
+        )
+
+      paths = Enum.map(report.top_paths, & &1.path)
+      refute "/direct-a" in paths
+      assert "/direct-b" in paths
+    end
+
+    test "path: filters every breakdown down to that exact path" do
+      session_a = "sess_#{System.unique_integer([:positive])}"
+      session_b = "sess_#{System.unique_integer([:positive])}"
+      base = unique_base()
+
+      insert_page_view(session_a, "/path-a", "US", "https://google.com/search", base)
+      insert_page_view(session_b, "/path-b", "CA", nil, base)
+
+      {:ok, report} =
+        Analytics.stats(DateTime.add(base, -1, :minute), DateTime.add(base, 1, :minute),
+          path: "/path-a"
+        )
+
+      assert report.summary.views == 1
+      assert [%{path: "/path-a"}] = report.top_paths
+      assert [%{country: "US"}] = report.top_countries
+      assert [%{source: "google.com"}] = report.top_referrers
+    end
+
+    test "country: filters to that exact country, and \"Unknown\" means no country" do
+      session_us = "sess_#{System.unique_integer([:positive])}"
+      session_unknown = "sess_#{System.unique_integer([:positive])}"
+      base = unique_base()
+
+      insert_page_view(session_us, "/country-a", "US", nil, base)
+      insert_page_view(session_unknown, "/country-b", nil, nil, base)
+
+      {:ok, us_report} =
+        Analytics.stats(DateTime.add(base, -1, :minute), DateTime.add(base, 1, :minute),
+          country: "US"
+        )
+
+      assert Enum.map(us_report.top_paths, & &1.path) == ["/country-a"]
+
+      {:ok, unknown_report} =
+        Analytics.stats(DateTime.add(base, -1, :minute), DateTime.add(base, 1, :minute),
+          country: "Unknown"
+        )
+
+      assert Enum.map(unknown_report.top_paths, & &1.path) == ["/country-b"]
+    end
+
+    test "filters combine (AND) rather than override each other" do
+      session_id = "sess_#{System.unique_integer([:positive])}"
+      base = unique_base()
+
+      insert_page_view(session_id, "/combo-a", "US", "https://google.com/search", base)
+      insert_page_view(session_id, "/combo-b", "US", "https://google.com/search", base)
+
+      {:ok, report} =
+        Analytics.stats(DateTime.add(base, -1, :minute), DateTime.add(base, 1, :minute),
+          path: "/combo-a",
+          country: "US",
+          referrer_contains: "google"
+        )
+
+      assert Enum.map(report.top_paths, & &1.path) == ["/combo-a"]
+    end
   end
 
   defp insert_page_view(session_id, path, country, referrer, %DateTime{} = occurred_at) do

--- a/test/blog_web/admin_auth_test.exs
+++ b/test/blog_web/admin_auth_test.exs
@@ -20,5 +20,16 @@ defmodule BlogWeb.AdminAuthTest do
 
     assert redirected_to(conn) == ~p"/admin"
     assert get_session(conn, :admin_authenticated) == true
+    assert get_session(conn, :admin_seen) == true
+  end
+
+  test "logging out clears admin_authenticated but keeps admin_seen", %{conn: conn} do
+    conn =
+      post(conn, ~p"/admin/login", %{"password" => Application.fetch_env!(:blog, :admin_password)})
+
+    conn = conn |> recycle() |> delete(~p"/admin/logout")
+
+    refute get_session(conn, :admin_authenticated)
+    assert get_session(conn, :admin_seen) == true
   end
 end

--- a/test/blog_web/live/admin/analytics_live_test.exs
+++ b/test/blog_web/live/admin/analytics_live_test.exs
@@ -48,7 +48,10 @@ defmodule BlogWeb.Admin.AnalyticsLiveTest do
     |> form("form", %{"range" => "30d", "referrer" => ""})
     |> render_change()
 
-    assert_patch(view, ~p"/admin/analytics?#{%{range: "30d", referrer: ""}}")
+    assert_patch(
+      view,
+      ~p"/admin/analytics?#{%{range: "30d", referrer: "", path: "", country: ""}}"
+    )
   end
 
   describe "click-to-filter" do
@@ -68,7 +71,11 @@ defmodule BlogWeb.Admin.AnalyticsLiveTest do
         |> element("button[phx-value-value='/foo']")
         |> render_click()
 
-      assert_patch(view, ~p"/admin/analytics?#{%{range: "all", referrer: "", path: "/foo", country: ""}}")
+      assert_patch(
+        view,
+        ~p"/admin/analytics?#{%{range: "all", referrer: "", path: "/foo", country: ""}}"
+      )
+
       assert html =~ "/foo"
       refute html =~ "/bar"
       assert html =~ "Filtered by"
@@ -78,7 +85,11 @@ defmodule BlogWeb.Admin.AnalyticsLiveTest do
         |> element("button", "Reset")
         |> render_click()
 
-      assert_patch(view, ~p"/admin/analytics?#{%{range: "all", referrer: "", path: "", country: ""}}")
+      assert_patch(
+        view,
+        ~p"/admin/analytics?#{%{range: "all", referrer: "", path: "", country: ""}}"
+      )
+
       assert html =~ "/foo"
       assert html =~ "/bar"
       refute html =~ "Filtered by"

--- a/test/blog_web/live/admin/analytics_live_test.exs
+++ b/test/blog_web/live/admin/analytics_live_test.exs
@@ -50,4 +50,75 @@ defmodule BlogWeb.Admin.AnalyticsLiveTest do
 
     assert_patch(view, ~p"/admin/analytics?#{%{range: "30d", referrer: ""}}")
   end
+
+  describe "click-to-filter" do
+    test "clicking a top path filters the whole report to it, and reset clears it", %{
+      conn: conn
+    } do
+      Analytics.track("page_view", %{path: "/foo", session_id: "sess-foo", country: "US"})
+      Analytics.track("page_view", %{path: "/bar", session_id: "sess-bar", country: "CA"})
+      :ok = Analytics.flush()
+
+      {:ok, view, html} = live(admin_conn(conn), ~p"/admin/analytics?range=all")
+      assert html =~ "/foo"
+      assert html =~ "/bar"
+
+      html =
+        view
+        |> element("button[phx-value-value='/foo']")
+        |> render_click()
+
+      assert_patch(view, ~p"/admin/analytics?#{%{range: "all", referrer: "", path: "/foo", country: ""}}")
+      assert html =~ "/foo"
+      refute html =~ "/bar"
+      assert html =~ "Filtered by"
+
+      html =
+        view
+        |> element("button", "Reset")
+        |> render_click()
+
+      assert_patch(view, ~p"/admin/analytics?#{%{range: "all", referrer: "", path: "", country: ""}}")
+      assert html =~ "/foo"
+      assert html =~ "/bar"
+      refute html =~ "Filtered by"
+    end
+
+    test "clicking a top country filters the report to it", %{conn: conn} do
+      Analytics.track("page_view", %{path: "/us-page", session_id: "sess-us", country: "US"})
+      Analytics.track("page_view", %{path: "/ca-page", session_id: "sess-ca", country: "CA"})
+      :ok = Analytics.flush()
+
+      {:ok, view, _html} = live(admin_conn(conn), ~p"/admin/analytics?range=all")
+
+      html =
+        view
+        |> element("button[phx-value-value='CA']")
+        |> render_click()
+
+      assert html =~ "/ca-page"
+      refute html =~ "/us-page"
+    end
+
+    test "clicking Direct in top referrers filters to sessions with no referrer", %{conn: conn} do
+      Analytics.track("page_view", %{
+        path: "/via-google",
+        session_id: "sess-google",
+        referrer: "https://google.com/search"
+      })
+
+      Analytics.track("page_view", %{path: "/direct-page", session_id: "sess-direct"})
+      :ok = Analytics.flush()
+
+      {:ok, view, _html} = live(admin_conn(conn), ~p"/admin/analytics?range=all")
+
+      html =
+        view
+        |> element("button[phx-value-value='direct']")
+        |> render_click()
+
+      assert html =~ "/direct-page"
+      refute html =~ "/via-google"
+    end
+  end
 end

--- a/test/blog_web/live/analytics_tracker_test.exs
+++ b/test/blog_web/live/analytics_tracker_test.exs
@@ -1,0 +1,41 @@
+defmodule BlogWeb.AnalyticsTrackerTest do
+  use BlogWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias Blog.Analytics
+
+  test "records a page_view for an ordinary visitor", %{conn: conn} do
+    sailor_id = "sailor_#{System.unique_integer([:positive])}"
+
+    {:ok, _view, _html} =
+      conn
+      |> put_connect_params(%{"sailor_id" => sailor_id})
+      |> live(~p"/writing")
+
+    assert count_page_views(sailor_id) == 1
+  end
+
+  test "skips tracking for a browser that has ever logged in as admin", %{conn: conn} do
+    sailor_id = "sailor_#{System.unique_integer([:positive])}"
+
+    {:ok, _view, _html} =
+      conn
+      |> Phoenix.ConnTest.init_test_session(%{})
+      |> Plug.Conn.put_session(:admin_seen, true)
+      |> put_connect_params(%{"sailor_id" => sailor_id})
+      |> live(~p"/writing")
+
+    assert count_page_views(sailor_id) == 0
+  end
+
+  defp count_page_views(sailor_id) do
+    :ok = Analytics.flush()
+
+    {:ok, _columns, rows} =
+      Analytics.query("SELECT COUNT(*) FROM events WHERE session_id = $1", [sailor_id])
+
+    [[count]] = rows
+    count
+  end
+end


### PR DESCRIPTION
- Set a durable, signed `admin_seen` session flag on successful admin
  login that (unlike `admin_authenticated`) survives logout, and extend
  the session cookie's lifetime so it persists across browser restarts.
  BlogWeb.AnalyticsTracker now skips tracking entirely for any browser
  carrying that flag, so the admin's own page views never show up in
  their own stats -- regardless of whether they're currently logged in.

- Extend Blog.Analytics.stats/3 with :path, :country, and :direct
  filter opts (in addition to the existing :referrer_contains),
  combinable with each other.

- Make each row in the analytics page's Top pages/countries/referrers
  lists clickable: clicking one filters the whole report down to it
  and the other breakdowns update accordingly. Active filters render
  as removable pills with a "Reset" control to clear them all.