### PR TITLE
Sea: interactivity backlog + arrival/departure toast

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -345,3 +345,8 @@ pre code.hljs {
   white-space: nowrap; color: oklch(0.6 0.19 25); background: var(--color-paper);
   border: 2px solid oklch(0.6 0.19 25); padding: 8px 16px;
   pointer-events: none; opacity: 0; transition: opacity 150ms ease; }
+.sea-toast { position: absolute; top: 48px; left: 50%; transform: translateX(-50%);
+  font-family: "Space Grotesk", system-ui, sans-serif; font-weight: 700;
+  font-size: clamp(12px, 1.6vw, 15px); letter-spacing: 0.02em; white-space: nowrap;
+  color: var(--color-ink); background: var(--color-paper); border: 2px solid var(--color-ink);
+  padding: 6px 14px; pointer-events: none; opacity: 0; transition: opacity 300ms ease; }

--- a/assets/js/sea/index.js
+++ b/assets/js/sea/index.js
@@ -83,6 +83,14 @@ class Sea {
     this.biteMsg.textContent = "🦈 Bitten! Watch the fins."
     el.appendChild(this.biteMsg)
 
+    this.toast = document.createElement("div")
+    this.toast.className = "sea-toast"
+    el.appendChild(this.toast)
+    this.toastQueue = []
+    this.toastTimer = null
+    this.net.onArrive = (flag) => this.queueToast(`${flag} a sailor has joined the sea`)
+    this.net.onDepart = (flag) => this.queueToast(`${flag} a sailor has left the sea`)
+
     this.onNavigate = (e) => {
       this.pos.x = e.detail.x
       this.pos.z = e.detail.z
@@ -311,6 +319,27 @@ class Sea {
     this.banner.style.opacity = "1"
   }
 
+  // One arrival/departure line at a time, queued so a burst of joins/leaves
+  // doesn't overwrite itself mid-fade.
+  queueToast(text) {
+    this.toastQueue.push(text)
+    if (!this.toastTimer) this.showNextToast()
+  }
+
+  showNextToast() {
+    const text = this.toastQueue.shift()
+    if (!text) {
+      this.toastTimer = null
+      return
+    }
+    this.toast.textContent = text
+    this.toast.style.opacity = "1"
+    this.toastTimer = setTimeout(() => {
+      this.toast.style.opacity = "0"
+      this.toastTimer = setTimeout(() => this.showNextToast(), 300)
+    }, 2500)
+  }
+
   dockTo(island) {
     // Leaving the sea to read a post. Mark that a sea session is paused (and
     // save where the boat was) so the destination page can offer a banner
@@ -329,9 +358,11 @@ class Sea {
     this.scene.dispose()
     seaBus.removeEventListener("sea:navigate", this.onNavigate)
     clearTimeout(this._biteMsgTimer)
+    clearTimeout(this.toastTimer)
     if (this.banner.parentNode) this.banner.remove()
     if (this.hint.parentNode) this.hint.remove()
     if (this.biteMsg.parentNode) this.biteMsg.remove()
+    if (this.toast.parentNode) this.toast.remove()
   }
 }
 

--- a/assets/js/sea/net.js
+++ b/assets/js/sea/net.js
@@ -8,6 +8,8 @@ export class SeaNet {
     this.roster = [] // [{id, path, flag}]
     this.remote = new Map() // id -> {x, z, h, tx, tz, th}  (t* = target)
     this.onRoster = null
+    this.onArrive = null // (flag) => void — another sailor joined Sea mode
+    this.onDepart = null // (flag) => void — another sailor left Sea mode
     this._lastSent = 0
 
     const token = document
@@ -29,7 +31,17 @@ export class SeaNet {
       cur.th = h
       this.remote.set(id, cur)
     })
-    this.channel.on("gone", ({id}) => this.remote.delete(id))
+    // The server already excludes the joining sailor from "arrived" via
+    // broadcast_from!, but "gone" (sent via broadcast! from terminate/2, when
+    // the leaving sailor's own socket is already closed) can't do the same —
+    // guard here so a sailor never toasts their own arrival/departure.
+    this.channel.on("arrived", ({id, flag}) => {
+      if (id !== this.sailorId && this.onArrive) this.onArrive(flag)
+    })
+    this.channel.on("gone", ({id, flag}) => {
+      this.remote.delete(id)
+      if (id !== this.sailorId && this.onDepart) this.onDepart(flag)
+    })
     this.channel.join()
   }
 

--- a/docs/superpowers/plans/2026-08-15-sea-interactivity-backlog.md
+++ b/docs/superpowers/plans/2026-08-15-sea-interactivity-backlog.md
@@ -16,7 +16,7 @@ chase cam, keyboard + touch controls, sidebar minimap.
 
 | # | Item | Status |
 |---|---|---|
-| 1 | Arrival/departure toast | Not started |
+| 1 | Arrival/departure toast | Done |
 | 2 | Ambient + event sound (muted by default) | Not started |
 | 3 | Wave/emote key | Not started |
 | 4 | Message in a bottle | Not started |

--- a/docs/superpowers/plans/2026-08-15-sea-interactivity-backlog.md
+++ b/docs/superpowers/plans/2026-08-15-sea-interactivity-backlog.md
@@ -1,0 +1,91 @@
+# Sea Interactivity Backlog
+
+A running list of ideas for making the `/sea` 3D easter egg more fun for
+people who join, to work through one at a time. Not a single implementation
+plan — each item gets scoped and built on its own, in priority order, and
+checked off here as it ships.
+
+**Baseline (already shipped, for context — see
+`docs/superpowers/specs/2026-07-25-3d-sailing-easter-egg-design.md`):**
+islands derived from every page, live multiplayer sailing over `SeaChannel`
+at ~12 Hz, reader boats anchored at their page's island with a country-flag
+sail, docking navigates to the post, ambient sharks that patrol/breach/bite,
+chase cam, keyboard + touch controls, sidebar minimap.
+
+## Status
+
+| # | Item | Status |
+|---|---|---|
+| 1 | Arrival/departure toast | Not started |
+| 2 | Ambient + event sound (muted by default) | Not started |
+| 3 | Wave/emote key | Not started |
+| 4 | Message in a bottle | Not started |
+| 5 | Trending islands from analytics | Not started |
+| 6 | Regatta / buoy objective | Not started |
+| 7 | Day/night cycle (Eastern time) | Not started |
+| 8 | Wake trails | Not started |
+| 9 | More ambient creatures/hazards | Not started |
+| 10 | Boat customization | Not started |
+
+---
+
+## 1. Arrival/departure moments
+
+A toast/banner when a sailor joins or leaves the sea (e.g. "🇯🇵 a sailor has
+joined the sea"), driven off `SeaChannel`'s presence diff / `"gone"` event.
+Makes the world feel alive instead of just populated.
+
+## 2. Ambient + event sound
+
+There's currently no audio in the scene. Add ambient waves/gulls plus short
+one-shots for collision splash, shark bite, and docking. **Must default to
+muted** — sound only starts after an explicit user opt-in (a mute/unmute
+control in the overlay), never autoplaying audio on entry. Persist the
+preference (localStorage) so it doesn't reset every visit.
+
+## 3. Wave/emote key
+
+A single low-effort social gesture — press a key to honk a horn / wave a
+flag / send up a firework — broadcast over `SeaChannel` like `pos` already
+is. Deliberately not chat: no text, no replies, just an acknowledgement.
+
+## 4. Message in a bottle
+
+Let a sailor drop a short (~80 char), ephemeral note that floats at a spot;
+other sailors read it by sailing close and pressing a key. No persistence
+beyond the channel's lifetime, no moderation queue — stays in the spirit of
+the "no chat" non-goal.
+
+## 5. Trending islands from analytics
+
+Surface `Blog.Analytics` view data in the world — a trending post's island
+stands out (taller, glowing, more palms) so exploring the sea surfaces
+what's popular right now.
+
+## 6. Regatta / buoy objective
+
+A chain of buoys to pass in order, with a session timer and maybe an
+ephemeral "fastest today" leaderboard shared over the roster. Gives sailing
+a goal beyond docking.
+
+## 7. Day/night cycle
+
+Tie the sky/lighting to real time of day instead of always looking the
+same. **Follow US Eastern time (America/New_York)** regardless of visitor
+timezone, so everyone sailing together sees the same sky at the same
+moment.
+
+## 8. Wake trails
+
+A fading plane strip behind moving boats so multiplayer sailing looks like
+sailing and you can see where people have been.
+
+## 9. More ambient creatures/hazards
+
+Beyond sharks: flying fish, an occasional surfacing whale, floating
+driftwood — variety without added gameplay complexity.
+
+## 10. Boat customization
+
+Let a visitor pick a hull color or flag emoji (localStorage-persisted)
+instead of always deriving hull color from a hash of the session id.

--- a/lib/blog_web/channels/sea_channel.ex
+++ b/lib/blog_web/channels/sea_channel.ex
@@ -6,6 +6,10 @@ defmodule BlogWeb.SeaChannel do
   right island. Sailors then broadcast their `{x, z, h}` position, which is
   fanned out to the other members and rendered as a live boat. Everything here
   is ephemeral — no storage.
+
+  Joining/leaving *this channel* (i.e. entering/exiting Sea mode, not just
+  visiting the site) also fans out `"arrived"` / `"gone"` events so other
+  sailors can show an arrival/departure toast.
   """
 
   use Phoenix.Channel
@@ -22,8 +26,19 @@ defmodule BlogWeb.SeaChannel do
 
   @impl true
   def handle_info(:after_join, socket) do
-    push(socket, "roster", %{sailors: roster()})
-    {:noreply, socket}
+    sailors = roster()
+    push(socket, "roster", %{sailors: sailors})
+
+    flag =
+      case Enum.find(sailors, &(&1.id == socket.assigns.sailor_id)) do
+        %{flag: flag} -> flag
+        nil -> "🏳️"
+      end
+
+    # Told to everyone already sailing, not this sailor themself — stash the
+    # flag in assigns so `terminate/2` can reuse it for the matching "gone".
+    broadcast_from!(socket, "arrived", %{id: socket.assigns.sailor_id, flag: flag})
+    {:noreply, assign(socket, :flag, flag)}
   end
 
   # A reader joined/left/navigated: refresh the roster for this sailor.
@@ -41,7 +56,7 @@ defmodule BlogWeb.SeaChannel do
   @impl true
   def terminate(_reason, socket) do
     if id = socket.assigns[:sailor_id] do
-      broadcast!(socket, "gone", %{id: id})
+      broadcast!(socket, "gone", %{id: id, flag: socket.assigns[:flag] || "🏳️"})
     end
 
     :ok

--- a/test/blog_web/channels/sea_channel_test.exs
+++ b/test/blog_web/channels/sea_channel_test.exs
@@ -42,11 +42,44 @@ defmodule BlogWeb.SeaChannelTest do
     refute_push "pos", %{id: "sailor-1"}
   end
 
-  test "leaving broadcasts a gone event" do
+  test "leaving broadcasts a gone event with the sailor's flag" do
     Process.flag(:trap_exit, true)
+
+    {:ok, _} =
+      Presence.track(self(), PresenceTracker.topic(), "reader-key", %{
+        country: "US",
+        sailor_id: "sailor-1",
+        path: "/writing",
+        joined_at: 0
+      })
+
     {:ok, _r1, socket1} = join_sea("sailor-1")
     ref = leave(socket1)
     assert_reply ref, :ok
-    assert_broadcast "gone", %{id: "sailor-1"}
+    assert_broadcast "gone", %{id: "sailor-1", flag: "🇺🇸"}
+  end
+
+  test "joining broadcasts an arrived event with the sailor's flag" do
+    {:ok, _} =
+      Presence.track(self(), PresenceTracker.topic(), "reader-key", %{
+        country: "GB",
+        sailor_id: "sailor-2",
+        path: "/",
+        joined_at: 0
+      })
+
+    {:ok, _r1, _socket1} = join_sea("sailor-1")
+    {:ok, _r2, _socket2} = join_sea("sailor-2")
+
+    # broadcast_from! is what excludes the joining sailor themself from this
+    # event, the same mechanism already covered for "pos" above.
+    assert_broadcast "arrived", %{id: "sailor-2", flag: "🇬🇧"}
+  end
+
+  test "a sailor with no presence entry arrives under a blank flag" do
+    {:ok, _r1, _socket1} = join_sea("sailor-1")
+    {:ok, _r2, _socket2} = join_sea("sailor-2")
+
+    assert_broadcast "arrived", %{id: "sailor-2", flag: "🏳️"}
   end
 end


### PR DESCRIPTION
## Summary

- Adds `docs/superpowers/plans/2026-08-15-sea-interactivity-backlog.md`, a running list of ideas for making `/sea` more fun for people who join, to work through one at a time.
- Implements the first item off that list: a toast when a sailor joins or leaves Sea mode (e.g. "🇯🇵 a sailor has joined the sea"), scoped to actual `SeaChannel` membership (entering/exiting Sea mode) rather than general site presence.

## Changes

- `lib/blog_web/channels/sea_channel.ex` — broadcasts a new `"arrived"` event (via `broadcast_from!`, so the joining sailor never sees their own toast) on channel join, carrying the sailor's flag; the existing `"gone"` event on `terminate/2` now also carries the flag.
- `assets/js/sea/net.js` — `SeaNet` exposes `onArrive`/`onDepart` callbacks wired to the new/updated channel events, with a client-side self-id guard as defense in depth.
- `assets/js/sea/index.js` — queues and displays a short-lived toast for each arrival/departure so a burst of events doesn't clobber itself mid-fade.
- `assets/css/app.css` — `.sea-toast` styling, matching the existing `.sea-bite`/`.sea-banner` overlay treatment.
- `test/blog_web/channels/sea_channel_test.exs` — coverage for the `"arrived"` broadcast (with and without a matching presence entry) and the flag now carried on `"gone"`.

## Testing

- `mix test` — not runnable in this session (no Elixir/Mix toolchain available in the sandbox); please run locally/CI before merging.
- Verified JS syntax with `node --input-type=module --check` on the changed files.

---
🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01J9Atddo3Ti1xYJFzPWyK9t)_