### PR TITLE
Add fullscreen focused writing mode to post editor

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -111,6 +111,34 @@
 }
 
 /* ─────────────────────────────────────────────────────────────
+   Post editor — focused writing mode. `.editor-pane` normally
+   flows inline (body textarea + rendered preview, stacked on
+   mobile, side by side at lg). Toggling `.is-fullscreen` (via
+   Phoenix.LiveView.JS, client-side only) lifts it out to cover
+   the viewport with the same left/right split at any width.
+   ───────────────────────────────────────────────────────────── */
+.editor-pane.is-fullscreen {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  padding: 1.5rem;
+  background: var(--color-paper);
+}
+.editor-pane.is-fullscreen > div {
+  display: flex;
+  height: 100%;
+  min-height: 0;
+  margin-bottom: 0;
+  flex-direction: column;
+}
+.editor-pane.is-fullscreen textarea,
+.editor-pane.is-fullscreen #preview {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+/* ─────────────────────────────────────────────────────────────
    Prose (rendered markdown post bodies).
    ───────────────────────────────────────────────────────────── */
 .markdown-content {

--- a/lib/blog_web/live/admin/post_form_live.ex
+++ b/lib/blog_web/live/admin/post_form_live.ex
@@ -84,6 +84,24 @@ defmodule BlogWeb.Admin.PostFormLive do
 
   defp render_preview(body), do: Content.render_markdown(body)
 
+  # Purely client-side: no server round-trip needed to enter/exit the
+  # focused writing mode, so the toggle stays instant.
+  defp toggle_fullscreen(js \\ %JS{}) do
+    js
+    |> JS.add_class("is-fullscreen", to: "#editor-pane")
+    |> JS.add_class("hidden", to: "#fullscreen-toggle")
+    |> JS.remove_class("hidden", to: "#fullscreen-exit")
+    |> JS.add_class("overflow-hidden", to: "body")
+  end
+
+  defp exit_fullscreen(js \\ %JS{}) do
+    js
+    |> JS.remove_class("is-fullscreen", to: "#editor-pane")
+    |> JS.remove_class("hidden", to: "#fullscreen-toggle")
+    |> JS.add_class("hidden", to: "#fullscreen-exit")
+    |> JS.remove_class("overflow-hidden", to: "body")
+  end
+
   defp slugify(title) do
     title
     |> String.downcase()
@@ -136,7 +154,32 @@ defmodule BlogWeb.Admin.PostFormLive do
 
           <.input field={@form[:published]} type="checkbox" label="Published (visible on site)" />
 
-          <div class="grid gap-6 lg:grid-cols-2">
+          <div class="mb-2 flex items-center justify-end">
+            <button
+              type="button"
+              id="fullscreen-toggle"
+              phx-click={toggle_fullscreen()}
+              class="border border-ink bg-paper px-3 py-[7px] text-[12px] font-semibold tracking-[0.04em] text-ink-2 transition-colors hover:bg-lime hover:text-on-lime"
+            >
+              ⤢ Full screen
+            </button>
+          </div>
+
+          <div
+            id="editor-pane"
+            class="editor-pane grid gap-6 lg:grid-cols-2"
+            phx-window-keydown={exit_fullscreen()}
+            phx-key="Escape"
+          >
+            <button
+              type="button"
+              id="fullscreen-exit"
+              phx-click={exit_fullscreen()}
+              class="absolute right-6 top-6 z-10 hidden border border-ink bg-paper px-3 py-[7px] text-[12px] font-semibold tracking-[0.04em] text-ink-2 transition-colors hover:bg-lime hover:text-on-lime"
+            >
+              ⤢ Exit full screen <span class="text-ink-3">&middot; Esc</span>
+            </button>
+
             <.input field={@form[:body]} type="textarea" label="Body (Markdown)" rows="24" />
             <div>
               <.label for="preview">Preview</.label>


### PR DESCRIPTION
## Summary
Adds a fullscreen focused writing mode to the post editor that allows writers to expand the editor pane to cover the entire viewport, eliminating distractions while composing content.

## Key Changes
- **Client-side toggle functions**: Added `toggle_fullscreen/1` and `exit_fullscreen/1` helper functions that use Phoenix LiveView's `JS` module to manage fullscreen state without server round-trips, ensuring instant UI feedback
- **Editor UI enhancements**: 
  - Added a "Full screen" button above the editor pane to enter fullscreen mode
  - Added an "Exit full screen" button (with Esc hint) that appears in the top-right corner when fullscreen is active
  - Wired Escape key binding to exit fullscreen mode via `phx-window-keydown`
- **Fullscreen styling**: Added comprehensive CSS rules for `.editor-pane.is-fullscreen` that:
  - Positions the editor as a fixed overlay covering the viewport
  - Maintains the two-column layout (textarea + preview) at any screen width
  - Ensures textarea and preview sections flex to fill available height
  - Applies proper padding and z-index layering

## Implementation Details
- The fullscreen state is purely client-side using Phoenix LiveView's `JS` commands, avoiding unnecessary server communication for a UI-only toggle
- The editor pane is wrapped in a new container (`#editor-pane`) to enable fullscreen positioning while keeping the form structure intact
- CSS uses flexbox within the fullscreen grid to ensure both editor and preview sections expand to fill vertical space
- Escape key provides an intuitive way to exit fullscreen mode alongside the explicit button

https://claude.ai/code/session_01D5vpymwmftckv9PhX3pijH