### PR TITLE
Sea: interactivity backlog (sound, wave gesture, more to come)

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -378,3 +378,6 @@ pre code.hljs {
   font-size: clamp(12px, 1.6vw, 15px); letter-spacing: 0.02em; white-space: nowrap;
   color: var(--color-ink); background: var(--color-paper); border: 2px solid var(--color-ink);
   padding: 6px 14px; pointer-events: none; opacity: 0; transition: opacity 300ms ease; }
+.sea-mute { position: absolute; top: 16px; right: 16px; width: 36px; height: 36px;
+  display: flex; align-items: center; justify-content: center; font-size: 16px;
+  border: 2px solid var(--color-ink); background: var(--color-paper); cursor: pointer; }

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -363,9 +363,12 @@ pre code.hljs {
   background: rgba(238,240,236,.5); position: relative; touch-action: none; }
 .sea-nub { width: 40px; height: 40px; background: var(--color-lime);
   border: 2px solid var(--color-ink); position: absolute; left: 26px; top: 26px; }
+.sea-buttons { display: flex; gap: 10px; align-items: flex-end; }
 .sea-dock { border: 2px solid var(--color-ink); background: var(--color-lime);
   color: var(--on-lime); font-weight: 700; text-transform: uppercase;
   letter-spacing: .08em; padding: 12px 18px; font-size: 13px; }
+.sea-wave-btn { width: 44px; height: 44px; border: 2px solid var(--color-ink);
+  background: var(--color-paper); font-size: 18px; }
 @media (hover: hover) and (pointer: fine) { .sea-touch { display: none; } }
 
 .sea-banner { position: absolute; top: 0; left: 0; transform: translate(-50%, -100%);

--- a/assets/js/sea/audio.js
+++ b/assets/js/sea/audio.js
@@ -153,6 +153,27 @@ export class SeaAudio {
     })
   }
 
+  // A short, friendly two-note toot for the wave/emote gesture — distinct
+  // from the bite's descending growl and the dock's three-note arpeggio.
+  wave() {
+    this._oneShot((ctx, out) => {
+      ;[440, 587.33].forEach((freq, i) => {
+        const osc = ctx.createOscillator()
+        osc.type = "triangle"
+        osc.frequency.value = freq
+        const gain = ctx.createGain()
+        const start = ctx.currentTime + i * 0.1
+        gain.gain.setValueAtTime(0, start)
+        gain.gain.linearRampToValueAtTime(0.4, start + 0.02)
+        gain.gain.exponentialRampToValueAtTime(0.001, start + 0.25)
+        osc.connect(gain)
+        gain.connect(out)
+        osc.start(start)
+        osc.stop(start + 0.25)
+      })
+    })
+  }
+
   // A little three-note major arpeggio for docking.
   dockChime() {
     this._oneShot((ctx, out) => {

--- a/assets/js/sea/audio.js
+++ b/assets/js/sea/audio.js
@@ -1,0 +1,188 @@
+// Lightweight WebAudio sound design for Sea mode. Everything is synthesized
+// (filtered noise + oscillators) rather than loaded from audio files, so
+// there's nothing to fetch and nothing added to the asset bundle.
+//
+// Muted by default, always — no autoplay, ever. Sound only starts from an
+// explicit `toggle()` call, which callers must wire to a real user gesture
+// (the mute button's click handler). If a visitor previously turned sound
+// on, that preference is remembered (localStorage), but actually resuming
+// audio on a later visit still waits for `armFromStoredPreference`'s
+// one-time listener to see a genuine user gesture (a keypress or tap),
+// which browser autoplay policies require regardless of prior consent.
+const MUTE_KEY = "seaMuted"
+
+export class SeaAudio {
+  constructor() {
+    this.ctx = null
+    this.master = null
+    this.ambientStarted = false
+    this.muted = localStorage.getItem(MUTE_KEY) !== "0"
+  }
+
+  // If the visitor previously left sound on, unmute as soon as they make any
+  // real gesture in the scene (first key press or touch) — satisfies
+  // autoplay policy without asking them to click a button they already
+  // opted into last time. `onChange` fires so the caller can refresh a mute
+  // button's icon.
+  armFromStoredPreference(el, onChange) {
+    if (this.muted) return
+    const resume = () => {
+      this.setMuted(false)
+      if (onChange) onChange()
+    }
+    el.addEventListener("keydown", resume, {once: true})
+    el.addEventListener("touchstart", resume, {once: true})
+    this._disarm = () => {
+      el.removeEventListener("keydown", resume)
+      el.removeEventListener("touchstart", resume)
+    }
+  }
+
+  toggle() {
+    this.setMuted(!this.muted)
+    return this.muted
+  }
+
+  setMuted(muted) {
+    this.muted = muted
+    localStorage.setItem(MUTE_KEY, muted ? "1" : "0")
+    if (muted) {
+      if (this.master) this.master.gain.setTargetAtTime(0, this._now(), 0.15)
+      return
+    }
+    if (!this.ctx) this._init()
+    if (this.ctx.state === "suspended") this.ctx.resume()
+    this.master.gain.setTargetAtTime(0.5, this._now(), 0.3)
+  }
+
+  _now() {
+    return this.ctx.currentTime
+  }
+
+  _init() {
+    const Ctx = window.AudioContext || window.webkitAudioContext
+    if (!Ctx) return
+    this.ctx = new Ctx()
+    this.master = this.ctx.createGain()
+    this.master.gain.value = 0 // ramped up by setMuted(false)
+    this.master.connect(this.ctx.destination)
+    this._startAmbientWaves()
+  }
+
+  // A loop of filtered noise with two slow LFOs wobbling its cutoff and
+  // level, so it reads as surf/wind swelling rather than a flat hiss.
+  _startAmbientWaves() {
+    if (this.ambientStarted) return
+    this.ambientStarted = true
+    const ctx = this.ctx
+
+    const src = ctx.createBufferSource()
+    src.buffer = this._noiseBuffer(4)
+    src.loop = true
+
+    const filter = ctx.createBiquadFilter()
+    filter.type = "lowpass"
+    filter.frequency.value = 500
+
+    const gain = ctx.createGain()
+    gain.gain.value = 0.35
+
+    src.connect(filter)
+    filter.connect(gain)
+    gain.connect(this.master)
+    src.start()
+
+    const cutoffLfo = ctx.createOscillator()
+    cutoffLfo.frequency.value = 0.08
+    const cutoffLfoGain = ctx.createGain()
+    cutoffLfoGain.gain.value = 250
+    cutoffLfo.connect(cutoffLfoGain)
+    cutoffLfoGain.connect(filter.frequency)
+    cutoffLfo.start()
+
+    const levelLfo = ctx.createOscillator()
+    levelLfo.frequency.value = 0.05
+    const levelLfoGain = ctx.createGain()
+    levelLfoGain.gain.value = 0.15
+    levelLfo.connect(levelLfoGain)
+    levelLfoGain.connect(gain.gain)
+    levelLfo.start()
+  }
+
+  _noiseBuffer(seconds) {
+    const len = Math.floor(seconds * this.ctx.sampleRate)
+    const buf = this.ctx.createBuffer(1, len, this.ctx.sampleRate)
+    const data = buf.getChannelData(0)
+    for (let i = 0; i < len; i++) data[i] = Math.random() * 2 - 1
+    return buf
+  }
+
+  // A short burst of filtered noise for hitting land or another boat.
+  splash() {
+    this._oneShot((ctx, out) => {
+      const src = ctx.createBufferSource()
+      src.buffer = this._noiseBuffer(0.3)
+      const filter = ctx.createBiquadFilter()
+      filter.type = "bandpass"
+      filter.frequency.value = 900
+      const gain = ctx.createGain()
+      gain.gain.setValueAtTime(0.6, ctx.currentTime)
+      gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.3)
+      src.connect(filter)
+      filter.connect(gain)
+      gain.connect(out)
+      src.start()
+      src.stop(ctx.currentTime + 0.3)
+    })
+  }
+
+  // A falling sawtooth growl for a shark bite.
+  biteAlarm() {
+    this._oneShot((ctx, out) => {
+      const osc = ctx.createOscillator()
+      osc.type = "sawtooth"
+      osc.frequency.setValueAtTime(220, ctx.currentTime)
+      osc.frequency.exponentialRampToValueAtTime(90, ctx.currentTime + 0.35)
+      const gain = ctx.createGain()
+      gain.gain.setValueAtTime(0.5, ctx.currentTime)
+      gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.35)
+      osc.connect(gain)
+      gain.connect(out)
+      osc.start()
+      osc.stop(ctx.currentTime + 0.35)
+    })
+  }
+
+  // A little three-note major arpeggio for docking.
+  dockChime() {
+    this._oneShot((ctx, out) => {
+      ;[523.25, 659.25, 784].forEach((freq, i) => {
+        const osc = ctx.createOscillator()
+        osc.type = "sine"
+        osc.frequency.value = freq
+        const gain = ctx.createGain()
+        const start = ctx.currentTime + i * 0.08
+        gain.gain.setValueAtTime(0, start)
+        gain.gain.linearRampToValueAtTime(0.35, start + 0.02)
+        gain.gain.exponentialRampToValueAtTime(0.001, start + 0.5)
+        osc.connect(gain)
+        gain.connect(out)
+        osc.start(start)
+        osc.stop(start + 0.5)
+      })
+    })
+  }
+
+  // Builds and discards its own nodes per call so overlapping triggers
+  // (e.g. two crashes in a row) don't fight over shared state. No-ops
+  // while muted so callers don't need to guard every call site.
+  _oneShot(build) {
+    if (this.muted || !this.ctx) return
+    build(this.ctx, this.master)
+  }
+
+  destroy() {
+    if (this._disarm) this._disarm()
+    if (this.ctx) this.ctx.close().catch(() => {})
+  }
+}

--- a/assets/js/sea/controls.js
+++ b/assets/js/sea/controls.js
@@ -1,10 +1,11 @@
 // Steering input for the local boat. `state.throttle` is 0..1 forward,
-// `state.turn` is -1..1 (left/right), `state.dock` latches true when the dock
-// key/button is pressed. Works with keyboard (arrows/WASD + space) and an
-// on-screen touch joystick + Dock button injected into `overlay`.
+// `state.turn` is -1..1 (left/right), `state.dock` and `state.emote` latch
+// true when their key/button is pressed. Works with keyboard (arrows/WASD +
+// space + E) and an on-screen touch joystick + Dock/Wave buttons injected
+// into `overlay`.
 
 export function createControls(overlay) {
-  const state = {throttle: 0, turn: 0, dock: false}
+  const state = {throttle: 0, turn: 0, dock: false, emote: false}
   const keys = new Set()
   let touchActive = false
   let touchTurn = 0
@@ -12,12 +13,13 @@ export function createControls(overlay) {
 
   const onKey = (down) => (e) => {
     const k = e.key.toLowerCase()
-    if (["arrowup", "arrowdown", "arrowleft", "arrowright", "w", "a", "s", "d", " "].includes(k)) {
+    if (["arrowup", "arrowdown", "arrowleft", "arrowright", "w", "a", "s", "d", " ", "e"].includes(k)) {
       e.preventDefault()
     }
     if (down) keys.add(k)
     else keys.delete(k)
     if (down && (k === " ")) state.dock = true
+    if (down && (k === "e")) state.emote = true
   }
   const kd = onKey(true)
   const ku = onKey(false)
@@ -31,7 +33,10 @@ export function createControls(overlay) {
     <div class="sea-stick" data-stick>
       <div class="sea-nub" data-nub></div>
     </div>
-    <button class="sea-dock" data-dock type="button">Dock</button>`
+    <div class="sea-buttons">
+      <button class="sea-wave-btn" data-wave type="button">👋</button>
+      <button class="sea-dock" data-dock type="button">Dock</button>
+    </div>`
   overlay.appendChild(pad)
 
   const stick = pad.querySelector("[data-stick]")
@@ -71,6 +76,7 @@ export function createControls(overlay) {
   stick.addEventListener("touchend", resetTouch)
   stick.addEventListener("touchcancel", resetTouch)
   pad.querySelector("[data-dock]").addEventListener("click", () => (state.dock = true))
+  pad.querySelector("[data-wave]").addEventListener("click", () => (state.emote = true))
 
   // Recompute turn/throttle from whichever input source is active every call,
   // so releasing a key (or the touch stick) actually zeroes it out instead of

--- a/assets/js/sea/index.js
+++ b/assets/js/sea/index.js
@@ -1,4 +1,4 @@
-import {SeaScene, flagTexture} from "./scene.js"
+import {SeaScene, flagTexture, emoteSprite} from "./scene.js"
 import {createControls} from "./controls.js"
 import {SeaNet} from "./net.js"
 import {SeaAudio} from "./audio.js"
@@ -28,6 +28,8 @@ const SHARK_BOUNDS = 140 // sharks patrol within this radius of the harbor
 const BITE_BOUNCE = -0.6 // harder knockback than a plain crash
 const BITE_COOLDOWN = 2 // seconds of invulnerability after a bite
 const DOCK_CHIME_DELAY = 150 // ms to let the chime start before navigating away
+const EMOTE_COOLDOWN = 0.8 // seconds between waves, so holding/mashing the key doesn't spam
+const EMOTE_DURATION = 1.3 // seconds the wave sprite rises and fades over
 
 let active = null
 
@@ -59,6 +61,8 @@ class Sea {
     this.pos = loadPos() || {x: harbor.x, z: harbor.z + 20, h: Math.PI}
     this.speed = 0
     this.wasColliding = false
+    this.emoteCooldown = 0
+    this.emotes = [] // active {sprite, boatGroup, t} wave sprites, see updateEmotes()
     this.selfBoat = this.scene.makeBoat(flagTexture("🏴"), true, sailorId)
 
     this.controls = createControls(el)
@@ -78,7 +82,7 @@ class Sea {
 
     this.hint = document.createElement("div")
     this.hint.className = "sea-hint"
-    this.hint.textContent = "Arrows / WASD to sail · Space to dock"
+    this.hint.textContent = "Arrows / WASD to sail · Space to dock · E to wave"
     el.appendChild(this.hint)
 
     this.biteMsg = document.createElement("div")
@@ -93,6 +97,15 @@ class Sea {
     this.toastTimer = null
     this.net.onArrive = (flag) => this.queueToast(`${flag} a sailor has joined the sea`)
     this.net.onDepart = (flag) => this.queueToast(`${flag} a sailor has left the sea`)
+    this.net.onEmote = (id) => {
+      // Best-effort visual: only attaches if that sailor's boat is currently
+      // rendered (live sailor or anchored reader). The sound plays either
+      // way, so a wave still reads as "someone out there waved" even if
+      // their boat isn't drawn (e.g. past MAX_BOATS).
+      const boat = this.remoteBoats.get(id) || this.readerBoats.get(id)
+      if (boat) this.spawnEmote(boat)
+      this.audio.wave()
+    }
 
     // Ambient waves + a few event sounds (splash, shark bite, dock chime).
     // Always muted on first visit — the mute button click is the only thing
@@ -179,6 +192,13 @@ class Sea {
       const isl = nearestDockable(this.pos.x, this.pos.z, this.islands)
       if (isl) this.dockTo(isl)
     }
+
+    if (this.emoteCooldown > 0) this.emoteCooldown -= 0.016
+    if (input.emote) {
+      input.emote = false
+      this.tryEmote()
+    }
+    this.updateEmotes()
 
     this.scene.animateWater(this.t)
     this.scene.chase(this.pos, this.pos.h)
@@ -315,6 +335,42 @@ class Sea {
   flagFor(id) {
     const s = this.net.roster.find((r) => r.id === id)
     return s ? s.flag : "🏳️"
+  }
+
+  // The wave/emote gesture: local feedback (sprite + sound) plus a network
+  // broadcast so other sailors see/hear it too. Cooldown-gated so holding
+  // or mashing the key doesn't spam either.
+  tryEmote() {
+    if (this.emoteCooldown > 0) return
+    this.emoteCooldown = EMOTE_COOLDOWN
+    this.spawnEmote(this.selfBoat)
+    this.audio.wave()
+    this.net.sendEmote()
+  }
+
+  spawnEmote(boatGroup) {
+    const sprite = emoteSprite("👋")
+    sprite.position.set(0, 6, 0)
+    boatGroup.add(sprite)
+    this.emotes.push({sprite, boatGroup, t: 0})
+  }
+
+  // Rises and fades each active wave sprite, removing it once its duration
+  // is up — run every frame regardless of whether *this* sailor just waved,
+  // since remote waves land in the same queue via `net.onEmote`.
+  updateEmotes() {
+    for (let i = this.emotes.length - 1; i >= 0; i--) {
+      const e = this.emotes[i]
+      e.t += 0.016
+      if (e.t >= EMOTE_DURATION) {
+        e.boatGroup.remove(e.sprite)
+        this.emotes.splice(i, 1)
+        continue
+      }
+      const p = e.t / EMOTE_DURATION
+      e.sprite.position.y = 6 + p * 2.5
+      e.sprite.material.opacity = 1 - p
+    }
   }
 
   // Floats the label above the actual island in the scene (not fixed to the

--- a/assets/js/sea/index.js
+++ b/assets/js/sea/index.js
@@ -1,6 +1,7 @@
 import {SeaScene, flagTexture} from "./scene.js"
 import {createControls} from "./controls.js"
 import {SeaNet} from "./net.js"
+import {SeaAudio} from "./audio.js"
 import {
   nearestDockable,
   nearestIsland,
@@ -26,6 +27,7 @@ const SHARK_COUNT = 5
 const SHARK_BOUNDS = 140 // sharks patrol within this radius of the harbor
 const BITE_BOUNCE = -0.6 // harder knockback than a plain crash
 const BITE_COOLDOWN = 2 // seconds of invulnerability after a bite
+const DOCK_CHIME_DELAY = 150 // ms to let the chime start before navigating away
 
 let active = null
 
@@ -56,6 +58,7 @@ class Sea {
     const harbor = this.islandsByPath.get("/") || {x: 0, z: 0}
     this.pos = loadPos() || {x: harbor.x, z: harbor.z + 20, h: Math.PI}
     this.speed = 0
+    this.wasColliding = false
     this.selfBoat = this.scene.makeBoat(flagTexture("🏴"), true, sailorId)
 
     this.controls = createControls(el)
@@ -90,6 +93,21 @@ class Sea {
     this.toastTimer = null
     this.net.onArrive = (flag) => this.queueToast(`${flag} a sailor has joined the sea`)
     this.net.onDepart = (flag) => this.queueToast(`${flag} a sailor has left the sea`)
+
+    // Ambient waves + a few event sounds (splash, shark bite, dock chime).
+    // Always muted on first visit — the mute button click is the only thing
+    // that can turn it on. See audio.js for the autoplay-safe details.
+    this.audio = new SeaAudio()
+    this.muteBtn = document.createElement("button")
+    this.muteBtn.className = "sea-mute"
+    this.muteBtn.type = "button"
+    this.refreshMuteBtn()
+    this.muteBtn.addEventListener("click", () => {
+      this.audio.toggle()
+      this.refreshMuteBtn()
+    })
+    el.appendChild(this.muteBtn)
+    this.audio.armFromStoredPreference(el, () => this.refreshMuteBtn())
 
     this.onNavigate = (e) => {
       this.pos.x = e.detail.x
@@ -131,7 +149,12 @@ class Sea {
     const nextZ = this.pos.z + Math.cos(this.pos.h) * this.speed
     const land = resolveCollision(nextX, nextZ, this.islands)
     const boats = resolveCollision(land.x, land.z, this.boatObstacles(), BOAT_COLLISION_MARGIN)
-    if (land.hit || boats.hit) this.speed *= CRASH_BOUNCE
+    const colliding = land.hit || boats.hit
+    if (colliding) this.speed *= CRASH_BOUNCE
+    // Edge-triggered so holding the throttle into an island plays one splash
+    // on impact, not one every frame for as long as contact continues.
+    if (colliding && !this.wasColliding) this.audio.splash()
+    this.wasColliding = colliding
     this.pos.x = boats.x
     this.pos.z = boats.z
 
@@ -182,6 +205,7 @@ class Sea {
 
     this.biteCooldown = BITE_COOLDOWN
     this.speed *= BITE_BOUNCE
+    this.audio.biteAlarm()
     const dx = this.pos.x - shark.x
     const dz = this.pos.z - shark.z
     const d = Math.hypot(dx, dz) || 0.001
@@ -340,6 +364,14 @@ class Sea {
     }, 2500)
   }
 
+  // Floats/hides the mute button's icon to match the audio module's actual
+  // state (which can change out from under a click — e.g. the stored-
+  // preference auto-resume on first keypress).
+  refreshMuteBtn() {
+    this.muteBtn.textContent = this.audio.muted ? "🔇" : "🔊"
+    this.muteBtn.setAttribute("aria-label", this.audio.muted ? "Unmute sea sounds" : "Mute sea sounds")
+  }
+
   dockTo(island) {
     // Leaving the sea to read a post. Mark that a sea session is paused (and
     // save where the boat was) so the destination page can offer a banner
@@ -347,7 +379,12 @@ class Sea {
     sessionStorage.seaActive = "1"
     sessionStorage.removeItem("seaBannerDismissed")
     savePos(this.pos)
-    window.location.href = island.path
+    this.audio.dockChime()
+    // A brief delay so the chime actually gets to start before the page
+    // unload cuts audio off — imperceptible as navigation latency.
+    setTimeout(() => {
+      window.location.href = island.path
+    }, DOCK_CHIME_DELAY)
   }
 
   destroy() {
@@ -355,6 +392,7 @@ class Sea {
     savePos(this.pos)
     this.controls.destroy()
     this.net.destroy()
+    this.audio.destroy()
     this.scene.dispose()
     seaBus.removeEventListener("sea:navigate", this.onNavigate)
     clearTimeout(this._biteMsgTimer)
@@ -363,6 +401,7 @@ class Sea {
     if (this.hint.parentNode) this.hint.remove()
     if (this.biteMsg.parentNode) this.biteMsg.remove()
     if (this.toast.parentNode) this.toast.remove()
+    if (this.muteBtn.parentNode) this.muteBtn.remove()
   }
 }
 

--- a/assets/js/sea/net.js
+++ b/assets/js/sea/net.js
@@ -10,6 +10,7 @@ export class SeaNet {
     this.onRoster = null
     this.onArrive = null // (flag) => void — another sailor joined Sea mode
     this.onDepart = null // (flag) => void — another sailor left Sea mode
+    this.onEmote = null // (id) => void — another sailor waved
     this._lastSent = 0
 
     const token = document
@@ -42,6 +43,9 @@ export class SeaNet {
       this.remote.delete(id)
       if (id !== this.sailorId && this.onDepart) this.onDepart(flag)
     })
+    this.channel.on("emote", ({id}) => {
+      if (id !== this.sailorId && this.onEmote) this.onEmote(id)
+    })
     this.channel.join()
   }
 
@@ -51,6 +55,10 @@ export class SeaNet {
     if (now - this._lastSent < 80) return
     this._lastSent = now
     this.channel.push("pos", {x, z, h})
+  }
+
+  sendEmote() {
+    this.channel.push("emote", {})
   }
 
   // Ease live boats toward their latest target; call each frame.

--- a/assets/js/sea/scene.js
+++ b/assets/js/sea/scene.js
@@ -393,6 +393,25 @@ export class SeaScene {
   }
 }
 
+// A billboarded emoji sprite (always faces the camera, unlike a plane mesh)
+// for the wave/emote gesture — a bare transparent glyph, not a flag swatch.
+// Callers attach it to a boat group and animate/remove it themselves.
+export function emoteSprite(emoji) {
+  const c = document.createElement("canvas")
+  c.width = c.height = 128
+  const ctx = c.getContext("2d")
+  ctx.font = "96px system-ui, 'Apple Color Emoji', 'Segoe UI Emoji', sans-serif"
+  ctx.textAlign = "center"
+  ctx.textBaseline = "middle"
+  ctx.fillText(emoji, 64, 70)
+  const tex = new THREE.CanvasTexture(c)
+  tex.needsUpdate = true
+  const mat = new THREE.SpriteMaterial({map: tex, transparent: true, depthTest: false})
+  const sprite = new THREE.Sprite(mat)
+  sprite.scale.set(3.2, 3.2, 1)
+  return sprite
+}
+
 // Builds a CanvasTexture showing an emoji flag on a lime sail.
 export function flagTexture(flag) {
   const c = document.createElement("canvas")

--- a/docs/superpowers/plans/2026-08-15-sea-interactivity-backlog.md
+++ b/docs/superpowers/plans/2026-08-15-sea-interactivity-backlog.md
@@ -17,7 +17,7 @@ chase cam, keyboard + touch controls, sidebar minimap.
 | # | Item | Status |
 |---|---|---|
 | 1 | Arrival/departure toast | Done |
-| 2 | Ambient + event sound (muted by default) | Not started |
+| 2 | Ambient + event sound (muted by default) | Done |
 | 3 | Wave/emote key | Not started |
 | 4 | Message in a bottle | Not started |
 | 5 | Trending islands from analytics | Not started |

--- a/docs/superpowers/plans/2026-08-15-sea-interactivity-backlog.md
+++ b/docs/superpowers/plans/2026-08-15-sea-interactivity-backlog.md
@@ -18,7 +18,7 @@ chase cam, keyboard + touch controls, sidebar minimap.
 |---|---|---|
 | 1 | Arrival/departure toast | Done |
 | 2 | Ambient + event sound (muted by default) | Done |
-| 3 | Wave/emote key | Not started |
+| 3 | Wave/emote key | Done |
 | 4 | Message in a bottle | Not started |
 | 5 | Trending islands from analytics | Not started |
 | 6 | Regatta / buoy objective | Not started |

--- a/lib/blog_web/channels/sea_channel.ex
+++ b/lib/blog_web/channels/sea_channel.ex
@@ -9,7 +9,9 @@ defmodule BlogWeb.SeaChannel do
 
   Joining/leaving *this channel* (i.e. entering/exiting Sea mode, not just
   visiting the site) also fans out `"arrived"` / `"gone"` events so other
-  sailors can show an arrival/departure toast.
+  sailors can show an arrival/departure toast. `"emote"` is a single,
+  content-free wave gesture fanned out the same way as `"pos"` — deliberately
+  not a chat channel.
   """
 
   use Phoenix.Channel
@@ -50,6 +52,14 @@ defmodule BlogWeb.SeaChannel do
   @impl true
   def handle_in("pos", %{"x" => x, "z" => z, "h" => h}, socket) do
     broadcast_from!(socket, "pos", %{id: socket.assigns.sailor_id, x: x, z: z, h: h})
+    {:noreply, socket}
+  end
+
+  # The wave/emote gesture — deliberately payload-free (no text, no
+  # customization) so it can't grow into a chat channel by accident.
+  @impl true
+  def handle_in("emote", _params, socket) do
+    broadcast_from!(socket, "emote", %{id: socket.assigns.sailor_id})
     {:noreply, socket}
   end
 

--- a/test/blog_web/channels/sea_channel_test.exs
+++ b/test/blog_web/channels/sea_channel_test.exs
@@ -82,4 +82,13 @@ defmodule BlogWeb.SeaChannelTest do
 
     assert_broadcast "arrived", %{id: "sailor-2", flag: "🏳️"}
   end
+
+  test "emotes broadcast to other members but not the sender" do
+    {:ok, _r1, socket1} = join_sea("sailor-1")
+
+    push(socket1, "emote", %{})
+
+    assert_broadcast "emote", %{id: "sailor-1"}
+    refute_push "emote", %{id: "sailor-1"}
+  end
 end


### PR DESCRIPTION
## Summary

Working through `docs/superpowers/plans/2026-08-15-sea-interactivity-backlog.md` one item at a time, all landing in this single PR (per request) instead of one PR per item.

**Done so far:**

- **#2 — Ambient + event sound, muted by default.** Everything synthesized via WebAudio (no audio files). Ambient wave noise plus one-shots: splash on collision, growl on shark bite, chime on docking. No `AudioContext` is created until the visitor clicks the new mute button — that's the only path that turns sound on. Preference persisted to `localStorage`; a later visit with sound previously on still waits for a real first gesture (keypress/tap) before resuming, per autoplay policy.
- **#3 — Wave/emote key.** Press `E` (or tap the new 👋 touch button) to wave: a billboarded emoji sprite rises and fades above your boat, a short toot plays, and it's broadcast over `SeaChannel` to every other sailor (their boat gets the same sprite + sound). Deliberately payload-free — no text, no customization, can't become chat.

**Still to come:** message in a bottle, trending islands from analytics, a regatta objective, day/night on Eastern time, wake trails, more ambient creatures, boat customization.

## Notable

- Merged `main` into this branch partway through (conflict in `assets/css/app.css` against the unrelated kudos-button work in #53/#54 — resolved by keeping both additions). That merge also pulled in `main`'s fix for the pre-existing `Blog.AnalyticsTest` flake I'd flagged in an earlier comment on this PR, so that's no longer a concern here.

## Testing

- `mix test` — not runnable in this sandbox (no Elixir/Mix toolchain available); please run locally/CI before merging.
- Verified JS syntax with `node --input-type=module --check` on all changed files.

---
🤖 Generated with [Claude Code](https://claude.ai/code)
