### PR TITLE
Sea: interactivity backlog, continued (items #4–#10, all done)

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -394,6 +394,12 @@ pre code.hljs {
 .sea-mute { position: absolute; top: 16px; right: 16px; width: 36px; height: 36px;
   display: flex; align-items: center; justify-content: center; font-size: 16px;
   border: 2px solid var(--color-ink); background: var(--color-paper); cursor: pointer; }
+.sea-bottle-banner { position: absolute; top: 0; left: 0; transform: translate(-50%, -100%);
+  font-family: "Space Grotesk", system-ui, sans-serif; font-style: italic; font-weight: 500;
+  font-size: clamp(12px, 1.6vw, 16px); color: var(--color-ink); max-width: 60vw;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  background: var(--color-paper); border: 2px solid var(--color-ink);
+  padding: 5px 10px; pointer-events: none; opacity: 0; transition: opacity 150ms ease; }
 
 /* Post footer kudos button (see the `Kudos` hook in app.js). The ring
    (--color-lime) fills clockwise over the 5s hold; the thumb grows with it.

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -400,6 +400,11 @@ pre code.hljs {
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
   background: var(--color-paper); border: 2px solid var(--color-ink);
   padding: 5px 10px; pointer-events: none; opacity: 0; transition: opacity 150ms ease; }
+.sea-regatta { position: absolute; top: 16px; left: 16px;
+  font-family: "Space Grotesk", system-ui, sans-serif; font-weight: 700;
+  font-size: clamp(11px, 1.5vw, 13px); letter-spacing: 0.04em; text-transform: uppercase;
+  color: var(--color-ink); background: var(--color-paper); border: 2px solid var(--color-ink);
+  padding: 6px 12px; pointer-events: none; opacity: 0; transition: opacity 200ms ease; }
 
 /* Post footer kudos button (see the `Kudos` hook in app.js). The ring
    (--color-lime) fills clockwise over the 5s hold; the thumb grows with it.

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -405,6 +405,17 @@ pre code.hljs {
   font-size: clamp(11px, 1.5vw, 13px); letter-spacing: 0.04em; text-transform: uppercase;
   color: var(--color-ink); background: var(--color-paper); border: 2px solid var(--color-ink);
   padding: 6px 12px; pointer-events: none; opacity: 0; transition: opacity 200ms ease; }
+.sea-customize-btn { position: absolute; top: 60px; right: 16px; width: 36px; height: 36px;
+  display: flex; align-items: center; justify-content: center; font-size: 16px;
+  border: 2px solid var(--color-ink); background: var(--color-paper); cursor: pointer; }
+.sea-customize-panel { position: absolute; top: 104px; right: 16px; display: none;
+  flex-direction: column; gap: 8px; background: var(--color-paper);
+  border: 2px solid var(--color-ink); padding: 10px; }
+.sea-swatches { display: grid; grid-template-columns: repeat(4, 1fr); gap: 6px; }
+.sea-swatch { width: 22px; height: 22px; border: 2px solid var(--color-ink); cursor: pointer; padding: 0; }
+.sea-flag-btn { border: 2px solid var(--color-ink); background: var(--color-paper);
+  color: var(--color-ink); font-weight: 700; text-transform: uppercase; letter-spacing: .06em;
+  font-size: 11px; padding: 8px 10px; cursor: pointer; }
 
 /* Post footer kudos button (see the `Kudos` hook in app.js). The ring
    (--color-lime) fills clockwise over the 5s hold; the thumb grows with it.

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -125,11 +125,15 @@ let Hooks = {
       ctx.clearRect(0, 0, w, h)
       const b = this.bounds()
 
-      ctx.fillStyle = this.themeColor("--color-ink-3")
+      const inkColor = this.themeColor("--color-ink-3")
+      const limeColor = this.themeColor("--color-lime")
       for (const isl of state.islands) {
         const {px, py} = this.toScreen(isl.x, isl.z, b)
+        // Trending islands stand out here too — bigger, lime dot instead of
+        // the muted default, matching the beacon in the 3D scene.
+        ctx.fillStyle = isl.trending ? limeColor : inkColor
         ctx.beginPath()
-        ctx.arc(px, py, 2.5, 0, Math.PI * 2)
+        ctx.arc(px, py, isl.trending ? 4 : 2.5, 0, Math.PI * 2)
         ctx.fill()
       }
 

--- a/assets/js/sea/audio.js
+++ b/assets/js/sea/audio.js
@@ -194,6 +194,28 @@ export class SeaAudio {
     })
   }
 
+  // A brighter four-note ascending run for finishing the regatta — bigger
+  // than the dock chime, since crossing the last buoy is a rarer, more
+  // deliberate accomplishment than every dock.
+  finishFanfare() {
+    this._oneShot((ctx, out) => {
+      ;[523.25, 659.25, 784, 1046.5].forEach((freq, i) => {
+        const osc = ctx.createOscillator()
+        osc.type = "triangle"
+        osc.frequency.value = freq
+        const gain = ctx.createGain()
+        const start = ctx.currentTime + i * 0.09
+        gain.gain.setValueAtTime(0, start)
+        gain.gain.linearRampToValueAtTime(0.4, start + 0.02)
+        gain.gain.exponentialRampToValueAtTime(0.001, start + 0.55)
+        osc.connect(gain)
+        gain.connect(out)
+        osc.start(start)
+        osc.stop(start + 0.55)
+      })
+    })
+  }
+
   // Builds and discards its own nodes per call so overlapping triggers
   // (e.g. two crashes in a row) don't fight over shared state. No-ops
   // while muted so callers don't need to guard every call site.

--- a/assets/js/sea/controls.js
+++ b/assets/js/sea/controls.js
@@ -1,11 +1,11 @@
 // Steering input for the local boat. `state.throttle` is 0..1 forward,
-// `state.turn` is -1..1 (left/right), `state.dock` and `state.emote` latch
-// true when their key/button is pressed. Works with keyboard (arrows/WASD +
-// space + E) and an on-screen touch joystick + Dock/Wave buttons injected
-// into `overlay`.
+// `state.turn` is -1..1 (left/right), `state.dock`/`state.emote`/`state.drop`
+// latch true when their key/button is pressed. Works with keyboard
+// (arrows/WASD + space + E + B) and an on-screen touch joystick +
+// Dock/Wave/Bottle buttons injected into `overlay`.
 
 export function createControls(overlay) {
-  const state = {throttle: 0, turn: 0, dock: false, emote: false}
+  const state = {throttle: 0, turn: 0, dock: false, emote: false, drop: false}
   const keys = new Set()
   let touchActive = false
   let touchTurn = 0
@@ -13,13 +13,14 @@ export function createControls(overlay) {
 
   const onKey = (down) => (e) => {
     const k = e.key.toLowerCase()
-    if (["arrowup", "arrowdown", "arrowleft", "arrowright", "w", "a", "s", "d", " ", "e"].includes(k)) {
+    if (["arrowup", "arrowdown", "arrowleft", "arrowright", "w", "a", "s", "d", " ", "e", "b"].includes(k)) {
       e.preventDefault()
     }
     if (down) keys.add(k)
     else keys.delete(k)
     if (down && (k === " ")) state.dock = true
     if (down && (k === "e")) state.emote = true
+    if (down && (k === "b")) state.drop = true
   }
   const kd = onKey(true)
   const ku = onKey(false)
@@ -35,6 +36,7 @@ export function createControls(overlay) {
     </div>
     <div class="sea-buttons">
       <button class="sea-wave-btn" data-wave type="button">👋</button>
+      <button class="sea-wave-btn" data-bottle type="button">🍾</button>
       <button class="sea-dock" data-dock type="button">Dock</button>
     </div>`
   overlay.appendChild(pad)
@@ -77,6 +79,7 @@ export function createControls(overlay) {
   stick.addEventListener("touchcancel", resetTouch)
   pad.querySelector("[data-dock]").addEventListener("click", () => (state.dock = true))
   pad.querySelector("[data-wave]").addEventListener("click", () => (state.emote = true))
+  pad.querySelector("[data-bottle]").addEventListener("click", () => (state.drop = true))
 
   // Recompute turn/throttle from whichever input source is active every call,
   // so releasing a key (or the touch stick) actually zeroes it out instead of

--- a/assets/js/sea/index.js
+++ b/assets/js/sea/index.js
@@ -1,4 +1,4 @@
-import {SeaScene, flagTexture, emoteSprite, bottleSprite, wakeSegment} from "./scene.js"
+import {SeaScene, flagTexture, emoteSprite, bottleSprite, wakeSegment, PALETTE} from "./scene.js"
 import {createControls} from "./controls.js"
 import {SeaNet} from "./net.js"
 import {SeaAudio} from "./audio.js"
@@ -47,6 +47,8 @@ const WAKE_DURATION = 1.6 // seconds a puff takes to fully fade
 const MAX_WAKES = 120 // hard cap so a crowded sea can't run away with the segment count
 const FISH_COUNT = 8
 const FISH_BOUNDS = 120 // flying fish patrol within this radius of the harbor
+const CUSTOM_COLOR_KEY = "seaCustomColor"
+const CUSTOM_FLAG_KEY = "seaCustomFlag"
 const BUOY_RESTING_SCALE = 3.2
 const BUOY_TARGET_SCALE = 4.6 // bigger than resting, marks the current target
 
@@ -95,7 +97,28 @@ class Sea {
     this.bottleMeshes = new Map() // id -> {sprite, bottle}
     this.wakes = [] // active {mesh, t} wake puffs, see updateWakes()
     this.lastWakePos = new Map() // sailorId -> {x, z}, throttles wake spawning by distance traveled
-    this.selfBoat = this.scene.makeBoat(flagTexture("🏴"), true, sailorId)
+    // A customized hull color/flag (see the 🎨 picker below) is applied
+    // right after creation, overriding the hash-derived hull color and the
+    // placeholder "🏴" flag for *this sailor's own view only* — other
+    // sailors still see this boat's hash-derived color and GeoIP flag, the
+    // same as before. Syncing a custom look to other viewers would need
+    // extending the presence/channel roster; left for later.
+    this.customColor = localStorage.getItem(CUSTOM_COLOR_KEY)
+    this.customFlag = localStorage.getItem(CUSTOM_FLAG_KEY)
+    this.selfBoat = this.scene.makeBoat(flagTexture(this.customFlag || "🏴"), true, sailorId)
+    if (this.customColor) this.scene.setHullColor(this.selfBoat, this.customColor)
+
+    this.customizeBtn = document.createElement("button")
+    this.customizeBtn.className = "sea-customize-btn"
+    this.customizeBtn.type = "button"
+    this.customizeBtn.textContent = "🎨"
+    this.customizeBtn.setAttribute("aria-label", "Customize your boat")
+    this.customizePanel = this.buildCustomizePanel()
+    this.customizeBtn.addEventListener("click", () => {
+      this.customizePanel.style.display = this.customizePanel.style.display === "none" ? "flex" : "none"
+    })
+    el.appendChild(this.customizeBtn)
+    el.appendChild(this.customizePanel)
 
     // Regatta: a fixed ring of buoys around the harbor, sailed in order.
     // Buoy 0 starts the clock; the last one stops it and reports a time.
@@ -687,6 +710,51 @@ class Sea {
     this.muteBtn.setAttribute("aria-label", this.audio.muted ? "Unmute sea sounds" : "Mute sea sounds")
   }
 
+  // Small hidden-by-default popover: a swatch per PALETTE color plus a
+  // "flag" button that prompts for an emoji, both applied immediately and
+  // persisted to localStorage. See the customColor/customFlag comment
+  // above for why this only affects this sailor's own view.
+  buildCustomizePanel() {
+    const panel = document.createElement("div")
+    panel.className = "sea-customize-panel"
+    panel.style.display = "none"
+
+    const swatches = document.createElement("div")
+    swatches.className = "sea-swatches"
+    for (const hex of PALETTE) {
+      const css = `#${hex.toString(16).padStart(6, "0")}`
+      const swatch = document.createElement("button")
+      swatch.type = "button"
+      swatch.className = "sea-swatch"
+      swatch.style.background = css
+      swatch.setAttribute("aria-label", `Set hull color ${css}`)
+      swatch.addEventListener("click", () => {
+        this.customColor = css
+        localStorage.setItem(CUSTOM_COLOR_KEY, css)
+        this.scene.setHullColor(this.selfBoat, css)
+      })
+      swatches.appendChild(swatch)
+    }
+    panel.appendChild(swatches)
+
+    const flagBtn = document.createElement("button")
+    flagBtn.type = "button"
+    flagBtn.className = "sea-flag-btn"
+    flagBtn.textContent = "Set sail flag"
+    flagBtn.addEventListener("click", () => {
+      const chosen = window.prompt("Sail flag/emoji:", this.customFlag || "🏴")
+      if (chosen == null) return
+      const trimmed = chosen.trim()
+      this.customFlag = trimmed || null
+      if (trimmed) localStorage.setItem(CUSTOM_FLAG_KEY, trimmed)
+      else localStorage.removeItem(CUSTOM_FLAG_KEY)
+      this.scene.setSailTexture(this.selfBoat, flagTexture(trimmed || "🏴"))
+    })
+    panel.appendChild(flagBtn)
+
+    return panel
+  }
+
   dockTo(island) {
     // Leaving the sea to read a post. Mark that a sea session is paused (and
     // save where the boat was) so the destination page can offer a banner
@@ -720,6 +788,8 @@ class Sea {
     if (this.muteBtn.parentNode) this.muteBtn.remove()
     if (this.bottleBanner.parentNode) this.bottleBanner.remove()
     if (this.regattaHud.parentNode) this.regattaHud.remove()
+    if (this.customizeBtn.parentNode) this.customizeBtn.remove()
+    if (this.customizePanel.parentNode) this.customizePanel.remove()
   }
 }
 

--- a/assets/js/sea/index.js
+++ b/assets/js/sea/index.js
@@ -1,10 +1,11 @@
-import {SeaScene, flagTexture, emoteSprite} from "./scene.js"
+import {SeaScene, flagTexture, emoteSprite, bottleSprite} from "./scene.js"
 import {createControls} from "./controls.js"
 import {SeaNet} from "./net.js"
 import {SeaAudio} from "./audio.js"
 import {
   nearestDockable,
   nearestIsland,
+  nearestBottle,
   isCloseEnoughToDock,
   resolveCollision,
   makeSharks,
@@ -30,6 +31,7 @@ const BITE_COOLDOWN = 2 // seconds of invulnerability after a bite
 const DOCK_CHIME_DELAY = 150 // ms to let the chime start before navigating away
 const EMOTE_COOLDOWN = 0.8 // seconds between waves, so holding/mashing the key doesn't spam
 const EMOTE_DURATION = 1.3 // seconds the wave sprite rises and fades over
+const BOTTLE_MAX_LENGTH = 80
 
 let active = null
 
@@ -63,6 +65,7 @@ class Sea {
     this.wasColliding = false
     this.emoteCooldown = 0
     this.emotes = [] // active {sprite, boatGroup, t} wave sprites, see updateEmotes()
+    this.bottleMeshes = new Map() // id -> {sprite, bottle}
     this.selfBoat = this.scene.makeBoat(flagTexture("🏴"), true, sailorId)
 
     this.controls = createControls(el)
@@ -82,8 +85,12 @@ class Sea {
 
     this.hint = document.createElement("div")
     this.hint.className = "sea-hint"
-    this.hint.textContent = "Arrows / WASD to sail · Space to dock · E to wave"
+    this.hint.textContent = "Arrows / WASD to sail · Space to dock · E to wave · B for a bottle"
     el.appendChild(this.hint)
+
+    this.bottleBanner = document.createElement("div")
+    this.bottleBanner.className = "sea-bottle-banner"
+    el.appendChild(this.bottleBanner)
 
     this.biteMsg = document.createElement("div")
     this.biteMsg.className = "sea-bite"
@@ -106,6 +113,8 @@ class Sea {
       if (boat) this.spawnEmote(boat)
       this.audio.wave()
     }
+    this.net.onBottleDropped = (bottle) => this.spawnBottle(bottle)
+    this.net.onBottleExpired = (id) => this.despawnBottle(id)
 
     // Ambient waves + a few event sounds (splash, shark bite, dock chime).
     // Always muted on first visit — the mute button click is the only thing
@@ -199,6 +208,13 @@ class Sea {
       this.tryEmote()
     }
     this.updateEmotes()
+
+    if (input.drop) {
+      input.drop = false
+      this.tryDropBottle()
+    }
+    this.updateBottles()
+    this.updateBottleBanner()
 
     this.scene.animateWater(this.t)
     this.scene.chase(this.pos, this.pos.h)
@@ -373,6 +389,65 @@ class Sea {
     }
   }
 
+  // Prompts for up to BOTTLE_MAX_LENGTH characters and, if given anything
+  // non-blank, drops it at the current position. A blocking native prompt
+  // is a deliberate simplification over a custom text-input overlay — it's
+  // a rare, deliberate action (unlike steering), and handles cancel/empty
+  // for free.
+  tryDropBottle() {
+    const text = window.prompt(`Drop a message in a bottle (max ${BOTTLE_MAX_LENGTH} chars):`, "")
+    if (text == null) return
+    const trimmed = text.trim().slice(0, BOTTLE_MAX_LENGTH)
+    if (!trimmed) return
+    this.net.dropBottle(round(this.pos.x), round(this.pos.z), trimmed)
+  }
+
+  spawnBottle(bottle) {
+    if (this.bottleMeshes.has(bottle.id)) return // already have it (e.g. duplicate join snapshot)
+    const sprite = bottleSprite()
+    sprite.position.set(bottle.x, 1.5, bottle.z)
+    this.scene.add(sprite)
+    this.bottleMeshes.set(bottle.id, {sprite, bottle})
+  }
+
+  despawnBottle(id) {
+    const entry = this.bottleMeshes.get(id)
+    if (!entry) return
+    this.scene.remove(entry.sprite)
+    this.bottleMeshes.delete(id)
+  }
+
+  // Gentle per-bottle bob, phase-offset by id so a cluster of bottles
+  // doesn't move in lockstep.
+  updateBottles() {
+    for (const {sprite, bottle} of this.bottleMeshes.values()) {
+      sprite.position.y = 1.5 + Math.sin(this.t * 1.2 + hash(String(bottle.id))) * 0.3
+    }
+  }
+
+  // Auto-reveals the nearest bottle's text once you're close enough to read
+  // it — no key needed, same "just approach it" treatment updateBanner()
+  // gives an island's title.
+  updateBottleBanner() {
+    const bottles = Array.from(this.bottleMeshes.values()).map((e) => e.bottle)
+    const near = nearestBottle(this.pos.x, this.pos.z, bottles)
+    if (!near) {
+      this.bottleBanner.style.opacity = "0"
+      return
+    }
+
+    const p = this.scene.project(near.bottle.x, 3, near.bottle.z)
+    if (!p.visible) {
+      this.bottleBanner.style.opacity = "0"
+      return
+    }
+
+    this.bottleBanner.textContent = `${near.bottle.flag} "${near.bottle.text}"`
+    this.bottleBanner.style.left = `${p.x}px`
+    this.bottleBanner.style.top = `${p.y}px`
+    this.bottleBanner.style.opacity = "1"
+  }
+
   // Floats the label above the actual island in the scene (not fixed to the
   // top of the screen) by projecting its 3D position to screen pixels each
   // frame, so it tracks the island as the chase cam moves.
@@ -458,6 +533,7 @@ class Sea {
     if (this.biteMsg.parentNode) this.biteMsg.remove()
     if (this.toast.parentNode) this.toast.remove()
     if (this.muteBtn.parentNode) this.muteBtn.remove()
+    if (this.bottleBanner.parentNode) this.bottleBanner.remove()
   }
 }
 

--- a/assets/js/sea/index.js
+++ b/assets/js/sea/index.js
@@ -11,7 +11,9 @@ import {
   makeSharks,
   stepShark,
   sharkBreach,
-  nearestBitingShark
+  nearestBitingShark,
+  regattaBuoys,
+  isAtBuoy
 } from "./world.js"
 import {seaBus} from "./bus.js"
 
@@ -32,6 +34,9 @@ const DOCK_CHIME_DELAY = 150 // ms to let the chime start before navigating away
 const EMOTE_COOLDOWN = 0.8 // seconds between waves, so holding/mashing the key doesn't spam
 const EMOTE_DURATION = 1.3 // seconds the wave sprite rises and fades over
 const BOTTLE_MAX_LENGTH = 80
+const REGATTA_BEST_KEY = "seaRegattaBest"
+const BUOY_RESTING_SCALE = 3.2
+const BUOY_TARGET_SCALE = 4.6 // bigger than resting, marks the current target
 
 let active = null
 
@@ -67,6 +72,24 @@ class Sea {
     this.emotes = [] // active {sprite, boatGroup, t} wave sprites, see updateEmotes()
     this.bottleMeshes = new Map() // id -> {sprite, bottle}
     this.selfBoat = this.scene.makeBoat(flagTexture("🏴"), true, sailorId)
+
+    // Regatta: a fixed ring of buoys around the harbor, sailed in order.
+    // Buoy 0 starts the clock; the last one stops it and reports a time.
+    this.buoys = regattaBuoys(harbor)
+    this.buoyMeshes = this.buoys.map((b) => {
+      const sprite = emoteSprite("🚩")
+      sprite.scale.set(BUOY_RESTING_SCALE, BUOY_RESTING_SCALE, 1)
+      sprite.position.set(b.x, 3, b.z)
+      this.scene.add(sprite)
+      return sprite
+    })
+    this.regattaNext = 0 // index of the next buoy that must be hit
+    this.regattaStart = null // this.t at buoy 0, or null when no run is active
+    this.regattaBest = parseFloat(localStorage.getItem(REGATTA_BEST_KEY)) || null
+
+    this.regattaHud = document.createElement("div")
+    this.regattaHud.className = "sea-regatta"
+    el.appendChild(this.regattaHud)
 
     this.controls = createControls(el)
     this.net = new SeaNet(sailorId)
@@ -115,6 +138,8 @@ class Sea {
     }
     this.net.onBottleDropped = (bottle) => this.spawnBottle(bottle)
     this.net.onBottleExpired = (id) => this.despawnBottle(id)
+    this.net.onRegattaFinish = (seconds) =>
+      this.queueToast(`🏁 a sailor finished the regatta in ${seconds.toFixed(1)}s`)
 
     // Ambient waves + a few event sounds (splash, shark bite, dock chime).
     // Always muted on first visit — the mute button click is the only thing
@@ -215,6 +240,8 @@ class Sea {
     }
     this.updateBottles()
     this.updateBottleBanner()
+
+    this.updateRegatta()
 
     this.scene.animateWater(this.t)
     this.scene.chase(this.pos, this.pos.h)
@@ -448,6 +475,63 @@ class Sea {
     this.bottleBanner.style.opacity = "1"
   }
 
+  // Bobs every buoy, keeps the current target visually bigger than the
+  // rest, and advances the regatta on a hit: buoy 0 starts the clock, the
+  // last buoy stops it, reports the time (local + broadcast), and resets
+  // for another lap.
+  updateRegatta() {
+    for (let i = 0; i < this.buoyMeshes.length; i++) {
+      const sprite = this.buoyMeshes[i]
+      const isTarget = i === this.regattaNext
+      const scale = isTarget ? BUOY_TARGET_SCALE : BUOY_RESTING_SCALE
+      sprite.scale.set(scale, scale, 1)
+      sprite.position.y = 3 + Math.sin(this.t * 1.3 + i) * 0.4
+    }
+
+    const target = this.buoys[this.regattaNext]
+    if (isAtBuoy(this.pos.x, this.pos.z, target)) {
+      if (this.regattaNext === 0) this.regattaStart = this.t
+      this.regattaNext += 1
+
+      if (this.regattaNext >= this.buoys.length) {
+        const elapsed = this.t - this.regattaStart
+        this.regattaNext = 0
+        this.regattaStart = null
+
+        const improved = this.regattaBest === null || elapsed < this.regattaBest
+        if (improved) {
+          this.regattaBest = elapsed
+          localStorage.setItem(REGATTA_BEST_KEY, String(elapsed))
+        }
+
+        this.audio.finishFanfare()
+        this.queueToast(
+          improved
+            ? `🏁 Regatta finished in ${elapsed.toFixed(1)}s — new best!`
+            : `🏁 Regatta finished in ${elapsed.toFixed(1)}s`
+        )
+        this.net.sendRegattaFinish(elapsed)
+      }
+    }
+
+    this.updateRegattaHud()
+  }
+
+  updateRegattaHud() {
+    if (this.regattaStart !== null) {
+      const elapsed = this.t - this.regattaStart
+      const best = this.regattaBest !== null ? ` · best ${this.regattaBest.toFixed(1)}s` : ""
+      this.regattaHud.textContent =
+        `Buoy ${this.regattaNext + 1}/${this.buoys.length} · ${elapsed.toFixed(1)}s${best}`
+      this.regattaHud.style.opacity = "1"
+    } else if (this.regattaBest !== null) {
+      this.regattaHud.textContent = `Regatta best: ${this.regattaBest.toFixed(1)}s`
+      this.regattaHud.style.opacity = "1"
+    } else {
+      this.regattaHud.style.opacity = "0"
+    }
+  }
+
   // Floats the label above the actual island in the scene (not fixed to the
   // top of the screen) by projecting its 3D position to screen pixels each
   // frame, so it tracks the island as the chase cam moves.
@@ -535,6 +619,7 @@ class Sea {
     if (this.toast.parentNode) this.toast.remove()
     if (this.muteBtn.parentNode) this.muteBtn.remove()
     if (this.bottleBanner.parentNode) this.bottleBanner.remove()
+    if (this.regattaHud.parentNode) this.regattaHud.remove()
   }
 }
 

--- a/assets/js/sea/index.js
+++ b/assets/js/sea/index.js
@@ -466,9 +466,10 @@ class Sea {
       return
     }
 
+    const title = island.trending ? `🔥 ${island.title}` : island.title
     this.banner.textContent = isCloseEnoughToDock(island, near.distance)
-      ? `${island.title} — press Space to dock`
-      : island.title
+      ? `${title} — press Space to dock`
+      : title
     this.banner.style.left = `${p.x}px`
     this.banner.style.top = `${p.y}px`
     this.banner.style.opacity = "1"

--- a/assets/js/sea/index.js
+++ b/assets/js/sea/index.js
@@ -13,7 +13,9 @@ import {
   sharkBreach,
   nearestBitingShark,
   regattaBuoys,
-  isAtBuoy
+  isAtBuoy,
+  easternHour,
+  dayFactor
 } from "./world.js"
 import {seaBus} from "./bus.js"
 
@@ -35,6 +37,7 @@ const EMOTE_COOLDOWN = 0.8 // seconds between waves, so holding/mashing the key 
 const EMOTE_DURATION = 1.3 // seconds the wave sprite rises and fades over
 const BOTTLE_MAX_LENGTH = 80
 const REGATTA_BEST_KEY = "seaRegattaBest"
+const TIME_OF_DAY_REFRESH_MS = 60_000 // sky doesn't need per-frame updates -- just re-check each minute
 const BUOY_RESTING_SCALE = 3.2
 const BUOY_TARGET_SCALE = 4.6 // bigger than resting, marks the current target
 
@@ -61,6 +64,16 @@ class Sea {
 
     this.scene = new SeaScene(el)
     for (const isl of islands) this.scene.addIsland(isl)
+
+    // Always follows US Eastern time, not the visitor's own timezone, so
+    // every sailor sees the same sky at once. Refreshed periodically rather
+    // than per-frame -- the sky doesn't need to update faster than once a
+    // minute, and this also catches a tab left open across the dawn/dusk
+    // curve or a DST transition.
+    this.scene.applyTimeOfDay(dayFactor(easternHour()))
+    this.timeOfDayTimer = setInterval(() => {
+      this.scene.applyTimeOfDay(dayFactor(easternHour()))
+    }, TIME_OF_DAY_REFRESH_MS)
 
     // Resume at the last saved spot (e.g. returning from a docked post);
     // otherwise start at the harbor.
@@ -613,6 +626,7 @@ class Sea {
     seaBus.removeEventListener("sea:navigate", this.onNavigate)
     clearTimeout(this._biteMsgTimer)
     clearTimeout(this.toastTimer)
+    clearInterval(this.timeOfDayTimer)
     if (this.banner.parentNode) this.banner.remove()
     if (this.hint.parentNode) this.hint.remove()
     if (this.biteMsg.parentNode) this.biteMsg.remove()

--- a/assets/js/sea/index.js
+++ b/assets/js/sea/index.js
@@ -1,4 +1,4 @@
-import {SeaScene, flagTexture, emoteSprite, bottleSprite} from "./scene.js"
+import {SeaScene, flagTexture, emoteSprite, bottleSprite, wakeSegment} from "./scene.js"
 import {createControls} from "./controls.js"
 import {SeaNet} from "./net.js"
 import {SeaAudio} from "./audio.js"
@@ -38,6 +38,9 @@ const EMOTE_DURATION = 1.3 // seconds the wave sprite rises and fades over
 const BOTTLE_MAX_LENGTH = 80
 const REGATTA_BEST_KEY = "seaRegattaBest"
 const TIME_OF_DAY_REFRESH_MS = 60_000 // sky doesn't need per-frame updates -- just re-check each minute
+const WAKE_SPAWN_DISTANCE = 2.5 // a boat drops one wake puff per this many units traveled
+const WAKE_DURATION = 1.6 // seconds a puff takes to fully fade
+const MAX_WAKES = 120 // hard cap so a crowded sea can't run away with the segment count
 const BUOY_RESTING_SCALE = 3.2
 const BUOY_TARGET_SCALE = 4.6 // bigger than resting, marks the current target
 
@@ -84,6 +87,8 @@ class Sea {
     this.emoteCooldown = 0
     this.emotes = [] // active {sprite, boatGroup, t} wave sprites, see updateEmotes()
     this.bottleMeshes = new Map() // id -> {sprite, bottle}
+    this.wakes = [] // active {mesh, t} wake puffs, see updateWakes()
+    this.lastWakePos = new Map() // sailorId -> {x, z}, throttles wake spawning by distance traveled
     this.selfBoat = this.scene.makeBoat(flagTexture("🏴"), true, sailorId)
 
     // Regatta: a fixed ring of buoys around the harbor, sailed in order.
@@ -220,6 +225,7 @@ class Sea {
 
     this.selfBoat.position.set(this.pos.x, 0, this.pos.z)
     this.selfBoat.rotation.y = this.pos.h
+    this.maybeSpawnWake(this.sailorId, this.pos.x, this.pos.z, this.pos.h)
 
     this.stepSharks()
 
@@ -255,6 +261,7 @@ class Sea {
     this.updateBottleBanner()
 
     this.updateRegatta()
+    this.updateWakes()
 
     this.scene.animateWater(this.t)
     this.scene.chase(this.pos, this.pos.h)
@@ -312,11 +319,13 @@ class Sea {
       }
       b.position.set(p.x, 0, p.z)
       b.rotation.y = p.h
+      this.maybeSpawnWake(id, p.x, p.z, p.h)
     }
     for (const [id, b] of this.remoteBoats) {
       if (!liveIds.has(id)) {
         this.scene.removeBoat(b)
         this.remoteBoats.delete(id)
+        this.lastWakePos.delete(id) // stop tracking distance-traveled for a sailor who's gone
       }
     }
 
@@ -343,6 +352,46 @@ class Sea {
         this.scene.removeBoat(b)
         this.readerBoats.delete(id)
       }
+    }
+  }
+
+  // Drops one wake puff behind `id`'s boat once it's traveled
+  // WAKE_SPAWN_DISTANCE since its last one — called for the self boat and
+  // every live remote sailor (not anchored readers, which don't move), so
+  // distance-since-last-spawn is what throttles density, not a fixed timer;
+  // a stationary boat naturally stops generating wake.
+  maybeSpawnWake(id, x, z, h) {
+    const last = this.lastWakePos.get(id)
+    if (last && Math.hypot(x - last.x, z - last.z) < WAKE_SPAWN_DISTANCE) return
+    this.lastWakePos.set(id, {x, z})
+
+    if (this.wakes.length >= MAX_WAKES) {
+      const oldest = this.wakes.shift()
+      this.scene.remove(oldest.mesh)
+    }
+
+    const mesh = wakeSegment()
+    // Drop it a little behind the stern rather than right under the boat.
+    mesh.position.set(x - Math.sin(h) * 2, 0.12, z - Math.cos(h) * 2)
+    mesh.rotation.y = h
+    this.scene.add(mesh)
+    this.wakes.push({mesh, t: 0})
+  }
+
+  // Fades and slightly spreads each active wake puff, removing it once its
+  // duration is up.
+  updateWakes() {
+    for (let i = this.wakes.length - 1; i >= 0; i--) {
+      const w = this.wakes[i]
+      w.t += 0.016
+      if (w.t >= WAKE_DURATION) {
+        this.scene.remove(w.mesh)
+        this.wakes.splice(i, 1)
+        continue
+      }
+      const p = w.t / WAKE_DURATION
+      w.mesh.material.opacity = 0.5 * (1 - p)
+      w.mesh.scale.setScalar(1 + p * 0.6)
     }
   }
 

--- a/assets/js/sea/index.js
+++ b/assets/js/sea/index.js
@@ -15,7 +15,11 @@ import {
   regattaBuoys,
   isAtBuoy,
   easternHour,
-  dayFactor
+  dayFactor,
+  makeFlyingFish,
+  stepFish,
+  fishLeap,
+  driftwoodPieces
 } from "./world.js"
 import {seaBus} from "./bus.js"
 
@@ -41,6 +45,8 @@ const TIME_OF_DAY_REFRESH_MS = 60_000 // sky doesn't need per-frame updates -- j
 const WAKE_SPAWN_DISTANCE = 2.5 // a boat drops one wake puff per this many units traveled
 const WAKE_DURATION = 1.6 // seconds a puff takes to fully fade
 const MAX_WAKES = 120 // hard cap so a crowded sea can't run away with the segment count
+const FISH_COUNT = 8
+const FISH_BOUNDS = 120 // flying fish patrol within this radius of the harbor
 const BUOY_RESTING_SCALE = 3.2
 const BUOY_TARGET_SCALE = 4.6 // bigger than resting, marks the current target
 
@@ -119,6 +125,17 @@ class Sea {
     this.sharks = makeSharks(SHARK_COUNT, SHARK_BOUNDS)
     this.sharkMeshes = this.sharks.map(() => this.scene.addShark())
     this.biteCooldown = 0
+
+    // Flying fish are the same story, minus the biting — pure atmosphere.
+    this.fish = makeFlyingFish(FISH_COUNT, FISH_BOUNDS)
+    this.fishMeshes = this.fish.map(() => this.scene.addFish())
+
+    // Driftwood is fully static set-dressing: built once, bobbed gently,
+    // never re-simulated.
+    this.driftwood = driftwoodPieces().map((piece) => ({
+      mesh: this.scene.addDriftwood(piece),
+      piece
+    }))
 
     this.banner = document.createElement("div")
     this.banner.className = "sea-banner"
@@ -228,6 +245,8 @@ class Sea {
     this.maybeSpawnWake(this.sailorId, this.pos.x, this.pos.z, this.pos.h)
 
     this.stepSharks()
+    this.stepAllFish()
+    this.bobDriftwood()
 
     this.net.sendPos(
       round(this.pos.x),
@@ -300,6 +319,24 @@ class Sea {
     this._biteMsgTimer = setTimeout(() => {
       this.biteMsg.style.opacity = "0"
     }, 1200)
+  }
+
+  // Advances every flying fish's patrol/leap state — pure atmosphere, no
+  // interaction with the boat at all (unlike sharks).
+  stepAllFish() {
+    for (let i = 0; i < this.fish.length; i++) {
+      const f = this.fish[i]
+      stepFish(f, 0.016, FISH_BOUNDS)
+      this.scene.updateFish(this.fishMeshes[i], f, fishLeap(f))
+    }
+  }
+
+  // Driftwood never moves horizontally — just a slow vertical bob,
+  // phase-offset per piece the same way reader boats and bottles are.
+  bobDriftwood() {
+    for (const {mesh, piece} of this.driftwood) {
+      mesh.position.y = 0.3 + Math.sin(this.t * 0.9 + hash(`${piece.x},${piece.z}`)) * 0.15
+    }
   }
 
   // Live sailors (from net.remote). A sailor id that is also in the roster is

--- a/assets/js/sea/net.js
+++ b/assets/js/sea/net.js
@@ -14,6 +14,7 @@ export class SeaNet {
     this.bottles = new Map() // id -> {id, x, z, text, flag}
     this.onBottleDropped = null // (bottle) => void
     this.onBottleExpired = null // (id) => void
+    this.onRegattaFinish = null // (seconds) => void — another sailor finished the regatta
     this._lastSent = 0
 
     const token = document
@@ -61,6 +62,9 @@ export class SeaNet {
       this.bottles.delete(id)
       if (this.onBottleExpired) this.onBottleExpired(id)
     })
+    this.channel.on("regatta_finish", ({id, seconds}) => {
+      if (id !== this.sailorId && this.onRegattaFinish) this.onRegattaFinish(seconds)
+    })
     this.channel.join()
   }
 
@@ -78,6 +82,10 @@ export class SeaNet {
 
   dropBottle(x, z, text) {
     this.channel.push("drop_bottle", {x, z, text})
+  }
+
+  sendRegattaFinish(seconds) {
+    this.channel.push("regatta_finish", {seconds})
   }
 
   _addBottle(bottle) {

--- a/assets/js/sea/net.js
+++ b/assets/js/sea/net.js
@@ -11,6 +11,9 @@ export class SeaNet {
     this.onArrive = null // (flag) => void — another sailor joined Sea mode
     this.onDepart = null // (flag) => void — another sailor left Sea mode
     this.onEmote = null // (id) => void — another sailor waved
+    this.bottles = new Map() // id -> {id, x, z, text, flag}
+    this.onBottleDropped = null // (bottle) => void
+    this.onBottleExpired = null // (id) => void
     this._lastSent = 0
 
     const token = document
@@ -46,6 +49,18 @@ export class SeaNet {
     this.channel.on("emote", ({id}) => {
       if (id !== this.sailorId && this.onEmote) this.onEmote(id)
     })
+    // "bottles" (the initial snapshot on join) and "bottle_dropped" (each
+    // subsequent one, including a bottle *this* sailor just dropped -- the
+    // server relays it back to every member rather than excluding the
+    // sender) both funnel through the same per-bottle callback.
+    this.channel.on("bottles", ({bottles}) => {
+      for (const b of bottles) this._addBottle(b)
+    })
+    this.channel.on("bottle_dropped", (bottle) => this._addBottle(bottle))
+    this.channel.on("bottle_expired", ({id}) => {
+      this.bottles.delete(id)
+      if (this.onBottleExpired) this.onBottleExpired(id)
+    })
     this.channel.join()
   }
 
@@ -59,6 +74,15 @@ export class SeaNet {
 
   sendEmote() {
     this.channel.push("emote", {})
+  }
+
+  dropBottle(x, z, text) {
+    this.channel.push("drop_bottle", {x, z, text})
+  }
+
+  _addBottle(bottle) {
+    this.bottles.set(bottle.id, bottle)
+    if (this.onBottleDropped) this.onBottleDropped(bottle)
   }
 
   // Ease live boats toward their latest target; call each frame.

--- a/assets/js/sea/scene.js
+++ b/assets/js/sea/scene.js
@@ -500,6 +500,22 @@ export function bottleSprite() {
   return sprite
 }
 
+// One puff of a boat's wake: a small flat, pale, translucent oblong laid on
+// the water surface. Caller positions/rotates it to trail behind a moving
+// boat and fades/grows it over time (see Sea#updateWakes in index.js) —
+// this just builds the mesh.
+export function wakeSegment() {
+  const geo = new THREE.PlaneGeometry(1.4, 2.4)
+  geo.rotateX(-Math.PI / 2)
+  const mat = new THREE.MeshBasicMaterial({
+    color: 0xf2f4ef,
+    transparent: true,
+    opacity: 0.5,
+    depthWrite: false
+  })
+  return new THREE.Mesh(geo, mat)
+}
+
 // Builds a CanvasTexture showing an emoji flag on a lime sail.
 export function flagTexture(flag) {
   const c = document.createElement("canvas")

--- a/assets/js/sea/scene.js
+++ b/assets/js/sea/scene.js
@@ -291,6 +291,17 @@ export class SeaScene {
     this.scene.remove(group)
   }
 
+  // Generic scene-graph attach/detach for standalone objects that aren't
+  // boats or islands (e.g. a bottle sprite) — keeps callers from reaching
+  // into the internal THREE.Scene directly.
+  add(object) {
+    this.scene.add(object)
+  }
+
+  remove(object) {
+    this.scene.remove(object)
+  }
+
   // A single raked fin blade: a thin triangle (root-to-root along the base,
   // swept tip above) extruded for thickness. Local origin is the *front*
   // root, extending backward (-z) and up (+y) from there, so callers place
@@ -409,6 +420,15 @@ export function emoteSprite(emoji) {
   const mat = new THREE.SpriteMaterial({map: tex, transparent: true, depthTest: false})
   const sprite = new THREE.Sprite(mat)
   sprite.scale.set(3.2, 3.2, 1)
+  return sprite
+}
+
+// A floating message-in-a-bottle marker: a smaller emoteSprite bobbing near
+// the waterline rather than above a boat's mast. Caller positions/animates
+// it (see Sea#updateBottles in index.js) and removes it on expiry.
+export function bottleSprite() {
+  const sprite = emoteSprite("🍾")
+  sprite.scale.set(2, 2, 1)
   return sprite
 }
 

--- a/assets/js/sea/scene.js
+++ b/assets/js/sea/scene.js
@@ -18,6 +18,28 @@ const COL = {
 // (non-trending) height — see SeaWorld/addIsland's `trending` flag.
 const TRENDING_HEIGHT_BOOST = 1.35
 
+// Day/night endpoints the scene lerps between — see applyTimeOfDay(). Kept
+// as plain hex numbers (not THREE.Color) since they're only ever fed
+// straight into `new THREE.Color(...)`.
+const NIGHT = {
+  sky: 0x161a33,
+  fogNear: 90,
+  fogFar: 240,
+  sunColor: 0x8fa0ff,
+  sunIntensity: 0.45,
+  hemiIntensity: 0.3,
+  sea: 0x1c2470
+}
+const DAY = {
+  sky: COL.paper,
+  fogNear: 120,
+  fogFar: 320,
+  sunColor: 0xffffff,
+  sunIntensity: 2.2,
+  hemiIntensity: 1.1,
+  sea: COL.sea
+}
+
 // A small family of fills at the same brightness/saturation as the brand's
 // lime and signal-blue accents, so colorful islands and boats still read as
 // "one system" — everything keeps the same thick ink outline regardless of
@@ -85,16 +107,35 @@ export class SeaScene {
     )
     this.camera.position.set(0, 24, 34)
 
-    const sun = new THREE.DirectionalLight(0xffffff, 2.2)
-    sun.position.set(30, 60, 20)
-    this.scene.add(sun)
-    this.scene.add(new THREE.HemisphereLight(COL.paper, COL.seaDark, 1.1))
+    this.sun = new THREE.DirectionalLight(0xffffff, 2.2)
+    this.sun.position.set(30, 60, 20)
+    this.scene.add(this.sun)
+    this.hemi = new THREE.HemisphereLight(COL.paper, COL.seaDark, 1.1)
+    this.scene.add(this.hemi)
 
     this._water()
 
     this.boats = new Map() // id -> {group}
     this._onResize = () => this.resize()
     window.addEventListener("resize", this._onResize)
+  }
+
+  // Blends sky/fog/lighting/sea between NIGHT and DAY. `t` is 0 (deepest
+  // night) .. 1 (brightest day) — see world.js's dayFactor(), which derives
+  // it from the real time of day in US Eastern regardless of the visitor's
+  // own timezone, so everyone sailing together sees the same sky at once.
+  applyTimeOfDay(t) {
+    const sky = new THREE.Color(NIGHT.sky).lerp(new THREE.Color(DAY.sky), t)
+    this.scene.background = sky
+    this.scene.fog.color = sky
+    this.scene.fog.near = THREE.MathUtils.lerp(NIGHT.fogNear, DAY.fogNear, t)
+    this.scene.fog.far = THREE.MathUtils.lerp(NIGHT.fogFar, DAY.fogFar, t)
+
+    this.sun.color = new THREE.Color(NIGHT.sunColor).lerp(new THREE.Color(DAY.sunColor), t)
+    this.sun.intensity = THREE.MathUtils.lerp(NIGHT.sunIntensity, DAY.sunIntensity, t)
+    this.hemi.intensity = THREE.MathUtils.lerp(NIGHT.hemiIntensity, DAY.hemiIntensity, t)
+
+    this.water.material.color = new THREE.Color(NIGHT.sea).lerp(new THREE.Color(DAY.sea), t)
   }
 
   _water() {

--- a/assets/js/sea/scene.js
+++ b/assets/js/sea/scene.js
@@ -14,6 +14,10 @@ const COL = {
   shark: 0x5b6470
 }
 
+// How much taller a trending island's silhouette stands versus its base
+// (non-trending) height — see SeaWorld/addIsland's `trending` flag.
+const TRENDING_HEIGHT_BOOST = 1.35
+
 // A small family of fills at the same brightness/saturation as the brand's
 // lime and signal-blue accents, so colorful islands and boats still read as
 // "one system" — everything keeps the same thick ink outline regardless of
@@ -116,13 +120,13 @@ export class SeaScene {
   // A cheap procedural palm: an ink trunk plus a squashed low-poly canopy.
   // Positions are derived from the island's hash so every sailor sees the
   // same trees in the same spots.
-  _palms(group, h, radius, baseY) {
+  _palms(group, h, radius, baseY, bonus = 0) {
     if (!this._palmTrunkGeo) {
       this._palmTrunkGeo = new THREE.CylinderGeometry(0.12, 0.18, 2.4)
       this._palmLeafGeo = new THREE.IcosahedronGeometry(0.9, 0)
     }
     const leafMat = new THREE.MeshToonMaterial({color: COL.palm, gradientMap: this.gradient})
-    const count = 2 + (h % 3) // 2..4
+    const count = 2 + (h % 3) + bonus // 2..4, more overgrown when trending
     for (let i = 0; i < count; i++) {
       const a = ((h >> (i * 5 + 1)) % 360) * (Math.PI / 180)
       const r = radius * (0.15 + ((h >> (i * 3 + 2)) % 40) / 100) // scattered near the shoreline
@@ -139,6 +143,23 @@ export class SeaScene {
     }
   }
 
+  // A soft lime glow standing above a trending island's peak — static
+  // (no per-frame animation needed) but unlit and translucent so it reads
+  // as a beacon rather than solid geometry, visible from well across the
+  // archipelago.
+  _beacon(group, peakY) {
+    const geo = new THREE.ConeGeometry(0.6, 6, 8)
+    const mat = new THREE.MeshBasicMaterial({
+      color: COL.lime,
+      transparent: true,
+      opacity: 0.55,
+      depthWrite: false
+    })
+    const beacon = new THREE.Mesh(geo, mat)
+    beacon.position.y = peakY + 3
+    group.add(beacon)
+  }
+
   // Islands are stacked hexagonal bands — a sand beach, a landmass slope,
   // and a peak (rocky if the island is tall) — plus a few palms, rather than
   // a single cone, so the silhouette reads as terrain rather than a triangle.
@@ -148,14 +169,19 @@ export class SeaScene {
     const group = new THREE.Group()
     const h = hashStr(island.path)
     const radius = 5 + ((h % 100) / 100) * 5 // 5..10
-    const height = 7 + (((h >> 8) % 100) / 100) * 9 // 7..16
+    const baseHeight = 7 + (((h >> 8) % 100) / 100) * 9 // 7..16
+    // Trending islands stand taller -- decide the peak's rock/vegetation
+    // fill from the *base* height first, so a trending boost never turns an
+    // otherwise-green peak to bare rock; it should read as overgrown, not
+    // just tall.
+    const fill = themedColor(island.color || island.section)
+    const peakFill = baseHeight > 12 ? COL.rock : fill
+    const height = island.trending ? baseHeight * TRENDING_HEIGHT_BOOST : baseHeight
     island.radius = radius
 
-    const fill = themedColor(island.color || island.section)
     const sandH = height * 0.16
     const slopeH = height * 0.5
     const peakH = height - sandH - slopeH
-    const peakFill = height > 12 ? COL.rock : fill
 
     let y = 0
     const beach = this._band(radius * 0.72, radius * 1.1, sandH, COL.sand)
@@ -175,7 +201,8 @@ export class SeaScene {
 
     island.height = y // actual peak height, used to float the label above it
 
-    this._palms(group, h, radius, sandH)
+    this._palms(group, h, radius, sandH, island.trending ? 2 : 0)
+    if (island.trending) this._beacon(group, y)
 
     group.position.set(island.x, 0, island.z)
     group.userData.island = island

--- a/assets/js/sea/scene.js
+++ b/assets/js/sea/scene.js
@@ -424,6 +424,55 @@ export class SeaScene {
     group.rotation.x = -breach * 0.4
   }
 
+  // A flying fish: a small silvery body plus one tail fin, much smaller
+  // than a shark and with no dorsal fin (nothing to look menacing about) —
+  // ambient variety, see world.js's fish patrol/leap helpers this renders.
+  addFish() {
+    const group = new THREE.Group()
+    const fishColor = 0x9fd3ff
+
+    const bodyGeo = new THREE.IcosahedronGeometry(0.4, 0)
+    const body = new THREE.Mesh(
+      bodyGeo,
+      new THREE.MeshToonMaterial({color: fishColor, gradientMap: this.gradient})
+    )
+    body.scale.set(0.7, 0.5, 1.6)
+    body.add(outline(bodyGeo, 1.1))
+    group.add(body)
+
+    const tail = this._finBlade(0.5, 0.4, 0.06, fishColor)
+    tail.position.set(0, 0, -0.7)
+    group.add(tail)
+
+    this.scene.add(group)
+    return group
+  }
+
+  // Applies one frame of a fish's simulated state (see world.js) — same
+  // shape as updateShark, but fish leap much higher relative to their size
+  // and never lean into a "bite" pose.
+  updateFish(group, fish, leap) {
+    group.position.set(fish.x, 0.3 + leap * 2.4, fish.z)
+    group.rotation.y = fish.h
+    group.rotation.x = -leap * 0.5
+  }
+
+  // One static piece of driftwood: a lime-toned ink-outlined log lying on
+  // its side. Purely decorative set-dressing (see world.js's
+  // driftwoodPieces) — no collision, no per-frame simulation beyond the
+  // caller's gentle bob.
+  addDriftwood(piece) {
+    const geo = new THREE.CylinderGeometry(0.22, 0.28, 3.2, 6)
+    const mat = new THREE.MeshToonMaterial({color: 0x8a6a45, gradientMap: this.gradient})
+    const log = new THREE.Mesh(geo, mat)
+    log.add(outline(geo, 1.08))
+    log.rotation.z = Math.PI / 2 // lie on its side rather than stand upright
+    log.rotation.y = piece.rot
+    log.position.set(piece.x, 0.3, piece.z)
+    this.scene.add(log)
+    return log
+  }
+
   // Cheap animated swell.
   animateWater(t) {
     const pos = this.waterGeo.attributes.position

--- a/assets/js/sea/scene.js
+++ b/assets/js/sea/scene.js
@@ -44,7 +44,11 @@ const DAY = {
 // lime and signal-blue accents, so colorful islands and boats still read as
 // "one system" — everything keeps the same thick ink outline regardless of
 // fill, which is what ties it together visually.
-const PALETTE = [
+// Exported so a sailor's boat-customization picker (see index.js) offers
+// exactly this palette — a custom hull color still "belongs" to the same
+// system as everyone else's hash-derived one, just chosen instead of
+// assigned.
+export const PALETTE = [
   0xc4e600, // lime (brand)
   0x4fd6c4, // teal
   0xff8a3d, // coral
@@ -310,6 +314,7 @@ export class SeaScene {
       new THREE.MeshToonMaterial({color: themedColor(sailorId), gradientMap: this.gradient})
     )
     hull.position.y = 1
+    hull.userData.isHull = true // lets setHullColor find it later without threading a reference through
     group.add(outline(hullGeo, 1.1).translateY(1))
     group.add(hull)
 
@@ -339,6 +344,7 @@ export class SeaScene {
     })
     const sail = new THREE.Mesh(sailGeo, sailMat)
     sail.position.set(0, 3.1, 0.2)
+    sail.userData.isSail = true // lets setSailTexture find it later
     group.add(sail)
 
     if (isSelf) {
@@ -353,6 +359,26 @@ export class SeaScene {
 
     this.scene.add(group)
     return group
+  }
+
+  // Re-tints an already-built boat's hull — used to apply a sailor's
+  // customized color over the hash-derived default (see index.js's
+  // boat-customization picker). No-op if `group` isn't a boat.
+  setHullColor(group, colorHex) {
+    const hull = group.children.find((c) => c.userData.isHull)
+    if (hull) hull.material.color.set(colorHex)
+  }
+
+  // Swaps an already-built boat's sail texture (e.g. a custom flag emoji
+  // instead of the hash/GeoIP default). Disposes the old texture -- unlike
+  // most meshes in this file, textures here are swapped at runtime rather
+  // than built once, so leaving the old one behind would actually leak.
+  setSailTexture(group, texture) {
+    const sail = group.children.find((c) => c.userData.isSail)
+    if (!sail) return
+    sail.material.map?.dispose()
+    sail.material.map = texture
+    sail.material.needsUpdate = true
   }
 
   removeBoat(group) {

--- a/assets/js/sea/world.js
+++ b/assets/js/sea/world.js
@@ -47,6 +47,29 @@ export function nearestIsland(x, z, islands) {
   return best ? {island: best, distance: Math.sqrt(bestD)} : null
 }
 
+const BOTTLE_READ_RADIUS = 12
+
+// Bottle whose position is nearest (x, z) and within reading range, or null
+// — used to auto-reveal a floating message-in-a-bottle's text as you
+// approach, the same "no key needed to see it" treatment as an island's
+// label banner.
+export function nearestBottle(x, z, bottles, radius = BOTTLE_READ_RADIUS) {
+  let best = null
+  let bestD = Infinity
+  for (const b of bottles) {
+    const dx = b.x - x
+    const dz = b.z - z
+    const d = dx * dx + dz * dz
+    if (d < bestD) {
+      bestD = d
+      best = b
+    }
+  }
+  if (!best) return null
+  const distance = Math.sqrt(bestD)
+  return distance <= radius ? {bottle: best, distance} : null
+}
+
 // True once a boat at `distance` from `island`'s center is close enough that
 // pressing dock would work — kept in sync with nearestDockable's threshold.
 export function isCloseEnoughToDock(island, distance, margin = DOCK_MARGIN) {

--- a/assets/js/sea/world.js
+++ b/assets/js/sea/world.js
@@ -160,3 +160,27 @@ export function nearestBitingShark(x, z, sharks, radius = SHARK_BITE_RADIUS) {
   }
   return null
 }
+
+// Regatta: a fixed ring of buoys around the harbor, sailed in order (buoy 0
+// starts the clock, the last one stops it). Purely a client-side layout —
+// same for every sailor since it's derived from the harbor position alone,
+// no server round-trip needed.
+const REGATTA_BUOY_COUNT = 5
+const REGATTA_RADIUS = 70
+const REGATTA_HIT_RADIUS = 7
+
+export function regattaBuoys(harbor) {
+  const buoys = []
+  for (let i = 0; i < REGATTA_BUOY_COUNT; i++) {
+    const angle = (i / REGATTA_BUOY_COUNT) * Math.PI * 2
+    buoys.push({
+      x: harbor.x + Math.cos(angle) * REGATTA_RADIUS,
+      z: harbor.z + Math.sin(angle) * REGATTA_RADIUS
+    })
+  }
+  return buoys
+}
+
+export function isAtBuoy(x, z, buoy, radius = REGATTA_HIT_RADIUS) {
+  return Math.hypot(buoy.x - x, buoy.z - z) <= radius
+}

--- a/assets/js/sea/world.js
+++ b/assets/js/sea/world.js
@@ -184,3 +184,27 @@ export function regattaBuoys(harbor) {
 export function isAtBuoy(x, z, buoy, radius = REGATTA_HIT_RADIUS) {
   return Math.hypot(buoy.x - x, buoy.z - z) <= radius
 }
+
+// Real-world day/night cycle, always following US Eastern time regardless
+// of the visitor's own timezone -- so everyone sailing together sees the
+// same sky at once. Intl.DateTimeFormat resolves America/New_York via the
+// browser's IANA tz database, which handles the EST/EDT DST transition
+// automatically (no manual UTC-offset math to get wrong).
+export function easternHour(date = new Date()) {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: "America/New_York",
+    hour: "numeric",
+    minute: "numeric",
+    hourCycle: "h23" // forces 0..23 (rather than en-US's default h24, which reports midnight as "24")
+  }).formatToParts(date)
+  const hour = Number(parts.find((p) => p.type === "hour").value)
+  const minute = Number(parts.find((p) => p.type === "minute").value)
+  return hour + minute / 60
+}
+
+// 0 (deepest night, ~1am ET) .. 1 (brightest day, ~1pm ET) — a smooth
+// cosine curve rather than discrete day/night/dawn/dusk buckets, so the sky
+// eases continuously through the day instead of snapping between states.
+export function dayFactor(hour) {
+  return (Math.cos(((hour - 13) / 24) * Math.PI * 2) + 1) / 2
+}

--- a/assets/js/sea/world.js
+++ b/assets/js/sea/world.js
@@ -208,3 +208,80 @@ export function easternHour(date = new Date()) {
 export function dayFactor(hour) {
   return (Math.cos(((hour - 13) / 24) * Math.PI * 2) + 1) / 2
 }
+
+// Flying fish: ambient and purely local, same reasoning as sharks (see
+// above) -- every visitor simulates their own, unsynced. Unlike sharks,
+// they never interact with the boat at all; leaping is just atmosphere.
+const FISH_SPEED = 0.22
+const FISH_JUMP_MIN = 2
+const FISH_JUMP_MAX = 6
+const FISH_JUMP_DURATION = 0.6
+
+export function makeFlyingFish(count, bounds, rand = Math.random) {
+  const fish = []
+  for (let i = 0; i < count; i++) {
+    fish.push({
+      x: (rand() - 0.5) * bounds * 2,
+      z: (rand() - 0.5) * bounds * 2,
+      h: rand() * Math.PI * 2,
+      turnBias: (rand() - 0.5) * 0.02,
+      jumpIn: FISH_JUMP_MIN + rand() * (FISH_JUMP_MAX - FISH_JUMP_MIN),
+      jumpT: 0
+    })
+  }
+  return fish
+}
+
+export function stepFish(fish, dt, bounds, rand = Math.random) {
+  fish.h += fish.turnBias + (rand() - 0.5) * 0.02
+  fish.x += Math.sin(fish.h) * FISH_SPEED
+  fish.z += Math.cos(fish.h) * FISH_SPEED
+  if (Math.hypot(fish.x, fish.z) > bounds) fish.h += Math.PI
+
+  if (fish.jumpT > 0) {
+    fish.jumpT -= dt
+    if (fish.jumpT <= 0) {
+      fish.jumpT = 0
+      fish.jumpIn = FISH_JUMP_MIN + rand() * (FISH_JUMP_MAX - FISH_JUMP_MIN)
+    }
+  } else {
+    fish.jumpIn -= dt
+    if (fish.jumpIn <= 0) fish.jumpT = FISH_JUMP_DURATION
+  }
+}
+
+// 0 (in the water) .. 1 (peak of the leap).
+export function fishLeap(fish) {
+  if (fish.jumpT <= 0) return 0
+  const p = 1 - fish.jumpT / FISH_JUMP_DURATION
+  return Math.sin(p * Math.PI)
+}
+
+// Floating driftwood: purely decorative set-dressing, no collision. Layout
+// is deterministic from each piece's index alone (a cheap integer hash, not
+// Math.random), so it's stable across reloads and identical for every
+// sailor without a server round-trip — the same reasoning as an island's
+// palm placement in scene.js.
+const DRIFTWOOD_COUNT = 14
+const DRIFTWOOD_BOUNDS = 130
+
+export function driftwoodPieces(count = DRIFTWOOD_COUNT, bounds = DRIFTWOOD_BOUNDS) {
+  const pieces = []
+  for (let i = 0; i < count; i++) {
+    const h = hashInt(i)
+    const angle = (h % 360) * (Math.PI / 180)
+    const radius = 20 + (((h >> 8) % 100) / 100) * bounds
+    pieces.push({
+      x: Math.cos(angle) * radius,
+      z: Math.sin(angle) * radius,
+      rot: ((h >> 16) % 360) * (Math.PI / 180)
+    })
+  }
+  return pieces
+}
+
+function hashInt(n) {
+  let h = Math.imul(n + 1, 2654435761) >>> 0
+  h ^= h >>> 15
+  return h
+}

--- a/docs/superpowers/plans/2026-08-15-sea-interactivity-backlog.md
+++ b/docs/superpowers/plans/2026-08-15-sea-interactivity-backlog.md
@@ -23,7 +23,7 @@ chase cam, keyboard + touch controls, sidebar minimap.
 | 5 | Trending islands from analytics | Done |
 | 6 | Regatta / buoy objective | Done |
 | 7 | Day/night cycle (Eastern time) | Done |
-| 8 | Wake trails | Not started |
+| 8 | Wake trails | Done |
 | 9 | More ambient creatures/hazards | Not started |
 | 10 | Boat customization | Not started |
 

--- a/docs/superpowers/plans/2026-08-15-sea-interactivity-backlog.md
+++ b/docs/superpowers/plans/2026-08-15-sea-interactivity-backlog.md
@@ -25,7 +25,7 @@ chase cam, keyboard + touch controls, sidebar minimap.
 | 7 | Day/night cycle (Eastern time) | Done |
 | 8 | Wake trails | Done |
 | 9 | More ambient creatures/hazards | Done |
-| 10 | Boat customization | Not started |
+| 10 | Boat customization | Done |
 
 ---
 
@@ -93,3 +93,10 @@ to keep the scene from getting crowded — can revisit later.
 
 Let a visitor pick a hull color or flag emoji (localStorage-persisted)
 instead of always deriving hull color from a hash of the session id.
+
+Shipped as self-view-only: a 🎨 picker sets your hull color (from the same
+palette the hash-derived system draws from) and sail flag/emoji, persisted
+and applied immediately to your own boat. Other sailors still see your
+hash-derived color and GeoIP flag — syncing a custom look to other viewers
+would need extending the presence/channel roster; left as a future
+follow-up rather than done here.

--- a/docs/superpowers/plans/2026-08-15-sea-interactivity-backlog.md
+++ b/docs/superpowers/plans/2026-08-15-sea-interactivity-backlog.md
@@ -19,7 +19,7 @@ chase cam, keyboard + touch controls, sidebar minimap.
 | 1 | Arrival/departure toast | Done |
 | 2 | Ambient + event sound (muted by default) | Done |
 | 3 | Wave/emote key | Done |
-| 4 | Message in a bottle | Not started |
+| 4 | Message in a bottle | Done |
 | 5 | Trending islands from analytics | Not started |
 | 6 | Regatta / buoy objective | Not started |
 | 7 | Day/night cycle (Eastern time) | Not started |

--- a/docs/superpowers/plans/2026-08-15-sea-interactivity-backlog.md
+++ b/docs/superpowers/plans/2026-08-15-sea-interactivity-backlog.md
@@ -22,7 +22,7 @@ chase cam, keyboard + touch controls, sidebar minimap.
 | 4 | Message in a bottle | Done |
 | 5 | Trending islands from analytics | Done |
 | 6 | Regatta / buoy objective | Done |
-| 7 | Day/night cycle (Eastern time) | Not started |
+| 7 | Day/night cycle (Eastern time) | Done |
 | 8 | Wake trails | Not started |
 | 9 | More ambient creatures/hazards | Not started |
 | 10 | Boat customization | Not started |

--- a/docs/superpowers/plans/2026-08-15-sea-interactivity-backlog.md
+++ b/docs/superpowers/plans/2026-08-15-sea-interactivity-backlog.md
@@ -20,7 +20,7 @@ chase cam, keyboard + touch controls, sidebar minimap.
 | 2 | Ambient + event sound (muted by default) | Done |
 | 3 | Wave/emote key | Done |
 | 4 | Message in a bottle | Done |
-| 5 | Trending islands from analytics | Not started |
+| 5 | Trending islands from analytics | Done |
 | 6 | Regatta / buoy objective | Not started |
 | 7 | Day/night cycle (Eastern time) | Not started |
 | 8 | Wake trails | Not started |

--- a/docs/superpowers/plans/2026-08-15-sea-interactivity-backlog.md
+++ b/docs/superpowers/plans/2026-08-15-sea-interactivity-backlog.md
@@ -24,7 +24,7 @@ chase cam, keyboard + touch controls, sidebar minimap.
 | 6 | Regatta / buoy objective | Done |
 | 7 | Day/night cycle (Eastern time) | Done |
 | 8 | Wake trails | Done |
-| 9 | More ambient creatures/hazards | Not started |
+| 9 | More ambient creatures/hazards | Done |
 | 10 | Boat customization | Not started |
 
 ---
@@ -84,6 +84,10 @@ sailing and you can see where people have been.
 
 Beyond sharks: flying fish, an occasional surfacing whale, floating
 driftwood — variety without added gameplay complexity.
+
+Shipped: flying fish (patrol + periodic leap, no interaction with the
+boat) and floating driftwood (static, gently bobbing). Skipped the whale
+to keep the scene from getting crowded — can revisit later.
 
 ## 10. Boat customization
 

--- a/docs/superpowers/plans/2026-08-15-sea-interactivity-backlog.md
+++ b/docs/superpowers/plans/2026-08-15-sea-interactivity-backlog.md
@@ -21,7 +21,7 @@ chase cam, keyboard + touch controls, sidebar minimap.
 | 3 | Wave/emote key | Done |
 | 4 | Message in a bottle | Done |
 | 5 | Trending islands from analytics | Done |
-| 6 | Regatta / buoy objective | Not started |
+| 6 | Regatta / buoy objective | Done |
 | 7 | Day/night cycle (Eastern time) | Not started |
 | 8 | Wake trails | Not started |
 | 9 | More ambient creatures/hazards | Not started |

--- a/lib/blog/application.ex
+++ b/lib/blog/application.ex
@@ -14,6 +14,7 @@ defmodule Blog.Application do
       {Blog.Analytics, Application.fetch_env!(:blog, Blog.Analytics)},
       Blog.SnakeGame,
       Blog.SandGame,
+      Blog.SeaBottles,
       BlogWeb.Endpoint
     ]
 

--- a/lib/blog/sea_bottles.ex
+++ b/lib/blog/sea_bottles.ex
@@ -1,0 +1,85 @@
+defmodule Blog.SeaBottles do
+  @moduledoc """
+  Ephemeral "message in a bottle" notes for the Sea easter egg. A sailor can
+  drop a short note at their current position; every sailor in Sea mode sees
+  it floating there until it expires on its own, then it's gone for good.
+
+  Deliberately not chat: one-way (no replies, no threading), short (capped
+  length), auto-expiring, and never written to disk — a small global
+  GenServer holds the current set in memory and broadcasts drops/expiries
+  over `Blog.PubSub` on `topic/0`, the same ephemeral pattern `Blog.SandGame`
+  and `Blog.SnakeGame` use for their shared state.
+  """
+  use GenServer
+
+  @topic "sea:bottles"
+  @max_length 80
+  @ttl_ms 5 * 60 * 1_000
+  # Bounds memory/broadcast volume regardless of who's dropping bottles (no
+  # auth on this channel) -- oldest active bottle is evicted early to make
+  # room rather than letting the set grow without limit.
+  @max_bottles 30
+
+  def start_link(_opts), do: GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+
+  def topic, do: @topic
+
+  @doc "Returns every currently-active bottle."
+  def list, do: GenServer.call(__MODULE__, :list)
+
+  @doc """
+  Drops a bottle at `{x, z}` carrying `text` (trimmed and capped to
+  #{@max_length} chars). A blank `text` is a no-op. Broadcasts
+  `{:bottle_dropped, bottle}` on `topic/0` and schedules its own
+  `{:bottle_expired, id}` broadcast after `ttl_ms`.
+  """
+  def drop(x, z, text, flag \\ "🏳️", ttl_ms \\ @ttl_ms) do
+    GenServer.cast(__MODULE__, {:drop, x, z, text, flag, ttl_ms})
+  end
+
+  @impl true
+  def init(:ok), do: {:ok, %{bottles: %{}}}
+
+  @impl true
+  def handle_call(:list, _from, state) do
+    {:reply, Map.values(state.bottles), state}
+  end
+
+  @impl true
+  def handle_cast({:drop, x, z, text, flag, ttl_ms}, state) do
+    text = text |> to_string() |> String.trim() |> String.slice(0, @max_length)
+
+    if text == "" do
+      {:noreply, state}
+    else
+      id = System.unique_integer([:positive, :monotonic])
+      bottle = %{id: id, x: x, z: z, text: text, flag: flag}
+      Process.send_after(self(), {:expire, id}, ttl_ms)
+
+      bottles = state.bottles |> evict_oldest_if_full() |> Map.put(id, bottle)
+      broadcast({:bottle_dropped, bottle})
+      {:noreply, %{state | bottles: bottles}}
+    end
+  end
+
+  @impl true
+  def handle_info({:expire, id}, state) do
+    if Map.has_key?(state.bottles, id) do
+      broadcast({:bottle_expired, id})
+      {:noreply, %{state | bottles: Map.delete(state.bottles, id)}}
+    else
+      # Already gone (e.g. evicted early to make room) -- nothing to do.
+      {:noreply, state}
+    end
+  end
+
+  defp evict_oldest_if_full(bottles) when map_size(bottles) < @max_bottles, do: bottles
+
+  defp evict_oldest_if_full(bottles) do
+    {oldest_id, _} = Enum.min_by(bottles, fn {id, _} -> id end)
+    broadcast({:bottle_expired, oldest_id})
+    Map.delete(bottles, oldest_id)
+  end
+
+  defp broadcast(msg), do: Phoenix.PubSub.broadcast(Blog.PubSub, @topic, msg)
+end

--- a/lib/blog_web/channels/sea_channel.ex
+++ b/lib/blog_web/channels/sea_channel.ex
@@ -17,6 +17,11 @@ defmodule BlogWeb.SeaChannel do
   `Blog.SeaBottles`'s ephemeral messages-in-bottles: a sailor drops a short
   note, everyone in Sea mode sees it float until it auto-expires. Also not
   chat — one-way, capped length, no thread.
+
+  `"regatta_finish"` fans a finish time out to the rest of the channel
+  (same `broadcast_from!` shape as `"emote"`) when a sailor completes the
+  buoy-ring regatta -- the ring itself is deterministic client-side layout,
+  not server state.
   """
 
   use Phoenix.Channel
@@ -90,6 +95,15 @@ defmodule BlogWeb.SeaChannel do
   @impl true
   def handle_in("drop_bottle", %{"x" => x, "z" => z, "text" => text}, socket) do
     SeaBottles.drop(x, z, text, socket.assigns[:flag] || "🏳️")
+    {:noreply, socket}
+  end
+
+  # The regatta buoy ring is entirely client-side (deterministic from the
+  # harbor position, see world.js's regattaBuoys) -- this just fans out a
+  # finish-line brag to other sailors, the same shape as "emote".
+  @impl true
+  def handle_in("regatta_finish", %{"seconds" => seconds}, socket) do
+    broadcast_from!(socket, "regatta_finish", %{id: socket.assigns.sailor_id, seconds: seconds})
     {:noreply, socket}
   end
 

--- a/lib/blog_web/channels/sea_channel.ex
+++ b/lib/blog_web/channels/sea_channel.ex
@@ -12,10 +12,16 @@ defmodule BlogWeb.SeaChannel do
   sailors can show an arrival/departure toast. `"emote"` is a single,
   content-free wave gesture fanned out the same way as `"pos"` — deliberately
   not a chat channel.
+
+  `"drop_bottle"` / `"bottle_dropped"` / `"bottle_expired"` relay
+  `Blog.SeaBottles`'s ephemeral messages-in-bottles: a sailor drops a short
+  note, everyone in Sea mode sees it float until it auto-expires. Also not
+  chat — one-way, capped length, no thread.
   """
 
   use Phoenix.Channel
 
+  alias Blog.SeaBottles
   alias BlogWeb.Presence
   alias BlogWeb.PresenceTracker
 
@@ -23,6 +29,7 @@ defmodule BlogWeb.SeaChannel do
   def join("sea:ocean", %{"sailor_id" => sailor_id}, socket) do
     send(self(), :after_join)
     Phoenix.PubSub.subscribe(Blog.PubSub, PresenceTracker.topic())
+    Phoenix.PubSub.subscribe(Blog.PubSub, SeaBottles.topic())
     {:ok, assign(socket, :sailor_id, sailor_id)}
   end
 
@@ -30,6 +37,7 @@ defmodule BlogWeb.SeaChannel do
   def handle_info(:after_join, socket) do
     sailors = roster()
     push(socket, "roster", %{sailors: sailors})
+    push(socket, "bottles", %{bottles: SeaBottles.list()})
 
     flag =
       case Enum.find(sailors, &(&1.id == socket.assigns.sailor_id)) do
@@ -49,6 +57,19 @@ defmodule BlogWeb.SeaChannel do
     {:noreply, socket}
   end
 
+  # Relayed straight through from Blog.SeaBottles's PubSub broadcast to every
+  # member (including the dropper — simpler than special-casing "it's mine",
+  # and it's how the dropper sees their own bottle land too).
+  def handle_info({:bottle_dropped, bottle}, socket) do
+    push(socket, "bottle_dropped", bottle)
+    {:noreply, socket}
+  end
+
+  def handle_info({:bottle_expired, id}, socket) do
+    push(socket, "bottle_expired", %{id: id})
+    {:noreply, socket}
+  end
+
   @impl true
   def handle_in("pos", %{"x" => x, "z" => z, "h" => h}, socket) do
     broadcast_from!(socket, "pos", %{id: socket.assigns.sailor_id, x: x, z: z, h: h})
@@ -60,6 +81,15 @@ defmodule BlogWeb.SeaChannel do
   @impl true
   def handle_in("emote", _params, socket) do
     broadcast_from!(socket, "emote", %{id: socket.assigns.sailor_id})
+    {:noreply, socket}
+  end
+
+  # Text length/blankness is validated in Blog.SeaBottles; a bottle that
+  # comes out blank after trimming is silently dropped (no broadcast at
+  # all), same as pressing "cancel" on the client's prompt.
+  @impl true
+  def handle_in("drop_bottle", %{"x" => x, "z" => z, "text" => text}, socket) do
+    SeaBottles.drop(x, z, text, socket.assigns[:flag] || "🏳️")
     {:noreply, socket}
   end
 

--- a/lib/blog_web/sea_world.ex
+++ b/lib/blog_web/sea_world.ex
@@ -6,8 +6,16 @@ defmodule BlogWeb.SeaWorld do
   hash of the path) and clustered by section so the layout is the same for
   everyone and stable across reloads. Publishing a post automatically adds an
   island the next time the page loads.
+
+  Each island also carries `trending: true/false` -- the top few pages by
+  view count over the last `@trending_window_hours` (from `Blog.Analytics`)
+  render taller/more overgrown, so sailing the archipelago surfaces what's
+  actually being read right now. Best-effort: if analytics is unavailable
+  for any reason, every island just comes back non-trending rather than
+  failing the whole island list.
   """
 
+  alias Blog.Analytics
   alias Blog.Content
 
   # Section index islands and the order/angle each section's cluster sits at.
@@ -26,13 +34,17 @@ defmodule BlogWeb.SeaWorld do
     {"games", "/games/sand", "Falling Sand"}
   ]
 
+  @trending_count 3
+  @trending_window_hours 24
+
   @type island :: %{
           path: String.t(),
           title: String.t(),
           section: String.t(),
           x: float(),
           z: float(),
-          color: String.t()
+          color: String.t(),
+          trending: boolean()
         }
 
   @spec islands() :: [island()]
@@ -51,11 +63,38 @@ defmodule BlogWeb.SeaWorld do
         {"notes", "/notes/#{p.slug}", p.title, color_key(p, "notes")}
       end)
 
+    trending = trending_paths()
+
     (fixed ++ posts ++ notes)
     |> Enum.map(fn {section, path, title, color} ->
       {x, z} = position(section, path)
-      %{path: path, title: title, section: section, x: x, z: z, color: color}
+
+      %{
+        path: path,
+        title: title,
+        section: section,
+        x: x,
+        z: z,
+        color: color,
+        trending: path in trending
+      }
     end)
+  end
+
+  # The top @trending_count paths by view count in the last
+  # @trending_window_hours, straight from the same stats/3 the admin
+  # analytics dashboard uses. Any failure (analytics down, a query error)
+  # degrades to "nothing is trending" rather than breaking island loading.
+  defp trending_paths do
+    to = DateTime.utc_now()
+    from = DateTime.add(to, -@trending_window_hours * 60 * 60, :second)
+
+    case Analytics.stats(from, to, limit: @trending_count) do
+      {:ok, %{top_paths: top_paths}} -> Enum.map(top_paths, & &1.path)
+      _ -> []
+    end
+  catch
+    :exit, _ -> []
   end
 
   # Colors are keyed off the post's category, falling back to its first tag,

--- a/test/blog/sea_bottles_test.exs
+++ b/test/blog/sea_bottles_test.exs
@@ -1,0 +1,44 @@
+defmodule Blog.SeaBottlesTest do
+  use ExUnit.Case, async: false
+
+  alias Blog.SeaBottles
+
+  setup do
+    Phoenix.PubSub.subscribe(Blog.PubSub, SeaBottles.topic())
+    :ok
+  end
+
+  test "drop/5 broadcasts the bottle and adds it to list/0" do
+    SeaBottles.drop(1.0, 2.0, "hello sailors", "🇺🇸")
+
+    assert_receive {:bottle_dropped, bottle}
+    assert bottle.x == 1.0
+    assert bottle.z == 2.0
+    assert bottle.text == "hello sailors"
+    assert bottle.flag == "🇺🇸"
+
+    assert Enum.any?(SeaBottles.list(), &(&1.id == bottle.id))
+  end
+
+  test "drop/5 trims and caps text to 80 characters" do
+    padded = "  " <> String.duplicate("x", 90) <> "  "
+    SeaBottles.drop(0, 0, padded)
+
+    assert_receive {:bottle_dropped, bottle}
+    assert bottle.text == String.duplicate("x", 80)
+  end
+
+  test "drop/5 is a no-op for blank text" do
+    SeaBottles.drop(0, 0, "   ")
+    refute_receive {:bottle_dropped, _}, 50
+  end
+
+  test "a bottle expires and is removed from list/0 after its ttl" do
+    SeaBottles.drop(3.0, 4.0, "gone soon", "🏳️", 10)
+
+    assert_receive {:bottle_dropped, bottle}
+    assert_receive {:bottle_expired, id}, 200
+    assert id == bottle.id
+    refute Enum.any?(SeaBottles.list(), &(&1.id == id))
+  end
+end

--- a/test/blog_web/channels/sea_channel_test.exs
+++ b/test/blog_web/channels/sea_channel_test.exs
@@ -91,4 +91,28 @@ defmodule BlogWeb.SeaChannelTest do
     assert_broadcast "emote", %{id: "sailor-1"}
     refute_push "emote", %{id: "sailor-1"}
   end
+
+  test "dropping a bottle relays a bottle_dropped push back to the dropper too" do
+    {:ok, _r1, socket1} = join_sea("sailor-1")
+
+    push(socket1, "drop_bottle", %{"x" => 5.0, "z" => 6.0, "text" => "ahoy"})
+
+    # Unlike pos/emote (broadcast_from!, sender excluded), this is relayed
+    # from Blog.SeaBottles's own PubSub broadcast, which every member —
+    # including the dropper — is subscribed to.
+    assert_push "bottle_dropped", %{x: 5.0, z: 6.0, text: "ahoy", flag: "🏳️"}
+  end
+
+  test "a fresh join receives the current bottles snapshot" do
+    Blog.SeaBottles.drop(9.0, 9.0, "already here")
+    # drop/5 casts; list/0 is a call to the same GenServer, so waiting for it
+    # to reply guarantees the cast above was already processed (same sender,
+    # same mailbox, strict FIFO) before we join below.
+    Blog.SeaBottles.list()
+
+    {:ok, _reply, _socket} = join_sea("sailor-1")
+
+    assert_push "bottles", %{bottles: bottles}
+    assert Enum.any?(bottles, &(&1.text == "already here"))
+  end
 end

--- a/test/blog_web/channels/sea_channel_test.exs
+++ b/test/blog_web/channels/sea_channel_test.exs
@@ -103,6 +103,15 @@ defmodule BlogWeb.SeaChannelTest do
     assert_push "bottle_dropped", %{x: 5.0, z: 6.0, text: "ahoy", flag: "🏳️"}
   end
 
+  test "regatta finishes broadcast to other members but not the sender" do
+    {:ok, _r1, socket1} = join_sea("sailor-1")
+
+    push(socket1, "regatta_finish", %{"seconds" => 42.5})
+
+    assert_broadcast "regatta_finish", %{id: "sailor-1", seconds: 42.5}
+    refute_push "regatta_finish", %{id: "sailor-1"}
+  end
+
   test "a fresh join receives the current bottles snapshot" do
     Blog.SeaBottles.drop(9.0, 9.0, "already here")
     # drop/5 casts; list/0 is a call to the same GenServer, so waiting for it

--- a/test/blog_web/sea_world_test.exs
+++ b/test/blog_web/sea_world_test.exs
@@ -90,6 +90,18 @@ defmodule BlogWeb.SeaWorldTest do
     assert a == b
   end
 
+  test "every island reports a boolean :trending flag" do
+    # Not asserting *which* island is trending: Blog.Analytics is one
+    # shared, singleton, in-memory store for the whole test run (like
+    # Blog.AnalyticsTest notes), so exact view counts/ranking here would be
+    # racing every other concurrently-running test that generates a real
+    # page view. This just proves the plumbing always yields a boolean
+    # rather than crashing island loading if analytics has a hiccup.
+    for island <- SeaWorld.islands() do
+      assert is_boolean(island.trending)
+    end
+  end
+
   test "unpublished posts get no island" do
     {:ok, _} =
       Blog.Content.create_post(%{


### PR DESCRIPTION
## Summary

Continuing `docs/superpowers/plans/2026-08-15-sea-interactivity-backlog.md` (items #1–#3 already merged in #55). All remaining items (#4–#10) are now done, landed one commit per item in this single PR per request. **The full backlog is complete.**

| # | Item | Notes |
|---|---|---|
| 4 | Message in a bottle | New `Blog.SeaBottles` GenServer (ephemeral, same pattern as `Blog.SandGame`/`Blog.SnakeGame`). `B` / 🍾 to drop a ≤80-char note; auto-expires after 5 min; sailing close auto-reveals it. |
| 5 | Trending islands from analytics | Top 3 pages by views in the last 24h (via the existing `Blog.Analytics.stats/3`) render taller, more overgrown, and with a lime beacon; best-effort, degrades to "nothing trending" if analytics has a hiccup. |
| 6 | Regatta / buoy objective | A fixed ring of 5 buoys around the harbor, sailed in order; a HUD shows the leg/time, a localStorage best time, and a finish gets broadcast to other sailors as a toast. |
| 7 | Day/night cycle | Sky/fog/lighting/sea color ease through a real day/night curve. **Always follows US Eastern time** (`America/New_York` via `Intl.DateTimeFormat`, DST-safe) regardless of the visitor's own timezone, so everyone sailing together sees the same sky at once. |
| 8 | Wake trails | Fading foam puffs trail behind the self boat and every live remote sailor, throttled by distance traveled (not a timer), capped at 120 segments. |
| 9 | More ambient creatures/hazards | Flying fish (patrol + periodic leap, no interaction with the boat) and floating driftwood (static, gently bobbing). Skipped the whale to avoid crowding the scene. |
| 10 | Boat customization | A 🎨 picker sets your hull color (from the existing themed palette) and sail flag/emoji, persisted to localStorage. **Self-view only** — other sailors still see your hash-derived color/GeoIP flag; syncing a custom look to other viewers would need extending the presence/channel roster, left as a future follow-up. |

## Notable

- Merged `main` into this branch partway through (conflict in `assets/css/app.css` against unrelated kudos-button work — resolved keeping both). That also pulled in `main`'s fix for the pre-existing `Blog.AnalyticsTest` flake flagged on the earlier PR, so it's not a concern here.
- Everything server-side stays ephemeral / in-memory (bottles, regatta broadcasts) — no new persistence, matching the rest of the Sea feature.

## Testing

- `mix test` — not runnable in this sandbox (no Elixir/Mix toolchain available); please run locally/CI before merging.
- Verified JS syntax with `node --input-type=module --check` on all changed files throughout. No JS test runner is configured in this repo, consistent with the existing untested `scene.js`/`controls.js`.

---
🤖 Generated with [Claude Code](https://claude.ai/code)
