### PR TITLE
Tune the kudos button: 3s hold, bottom-up fill, bigger grow

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -417,9 +417,10 @@ pre code.hljs {
   color: var(--color-ink); font-weight: 700; text-transform: uppercase; letter-spacing: .06em;
   font-size: 11px; padding: 8px 10px; cursor: pointer; }
 
-/* Post footer kudos button (see the `Kudos` hook in app.js). The ring
-   (--color-lime) fills clockwise over the 5s hold; the thumb grows with it.
-   .is-given is the resting "already given" state -- filled ring, no hover. */
+/* Post footer kudos button (see the `Kudos` hook in app.js). [data-kudos-fill]
+   (--color-lime) rises bottom-to-top over the 3s hold while the button
+   grows; .is-given is the resting "already given" state it lands on --
+   fully filled, no hover. */
 .kudos-button {
   cursor: pointer;
   background: var(--color-paper);
@@ -433,8 +434,11 @@ pre code.hljs {
   background: var(--color-lime);
   border-color: var(--color-lime);
 }
-.kudos-widget.is-holding .kudos-button {
-  background: var(--color-paper-2);
+.kudos-fill {
+  z-index: 0;
+}
+.kudos-thumb {
+  z-index: 1;
 }
 
 .kudos-confetti-field {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -261,26 +261,26 @@ let Hooks = {
       this.ctx.putImageData(img, 0, 0)
     }
   },
-  // The "hold for 5s to give kudos" button under each post. Hold state and
+  // The "hold for 3s to give kudos" button under each post. Hold state and
   // the completion fetch are entirely client-driven (phx-update="ignore" --
-  // see BlogWeb.PostLive.Show) so the confetti and progress fill never
-  // wait on a server round trip; the server only needs to know once, when
-  // the hold actually completes.
+  // see BlogWeb.PostLive.Show) so the confetti and fill never wait on a
+  // server round trip; the server only needs to know once, when the hold
+  // actually completes.
   Kudos: {
-    RADIUS: 15.5,
-    HOLD_MS: 5000,
+    HOLD_MS: 3000,
+    // Scale reached at the end of the hold -- big enough that "getting
+    // bigger" reads clearly rather than needing a side-by-side to notice.
+    HOLD_SCALE: 1.5,
 
     mounted() {
-      this.circumference = 2 * Math.PI * this.RADIUS
       this.button = this.el.querySelector("[data-kudos-button]")
-      this.progress = this.el.querySelector("[data-kudos-progress]")
+      this.fill = this.el.querySelector("[data-kudos-fill]")
       this.countEl = this.el.querySelector("[data-kudos-count]")
       this.labelEl = this.el.querySelector("[data-kudos-label]")
       this.path = this.el.dataset.path
       this.given = this.el.dataset.given === "true"
       this.timer = null
 
-      this.progress.style.strokeDasharray = `${this.circumference}`
       this.setFill(0, false)
 
       if (this.given) {
@@ -297,22 +297,28 @@ let Hooks = {
       if (this.timer) clearTimeout(this.timer)
     },
 
-    // fraction is 0..1 of the ring to fill; animate controls whether the
-    // fill transitions smoothly (holding/resetting) or jumps instantly
-    // (initial paint, already-given state).
+    // fraction is 0..1 of the square to fill from the bottom up; animate
+    // (ms, or false) controls whether the fill/color/icon transition
+    // smoothly (holding/resetting) or jump instantly (initial paint,
+    // already-given state). Fill and icon color move together so the
+    // button has already reached its "given" look the instant it's full.
     setFill(fraction, animate) {
-      this.progress.style.transition = animate
-        ? `stroke-dashoffset ${animate}ms ${fraction > 0 ? "linear" : "ease"}`
+      const transition = animate
+        ? `height ${animate}ms linear, color ${animate}ms ${fraction > 0 ? "ease-in" : "ease"}`
         : "none"
-      this.progress.style.strokeDashoffset = `${this.circumference * (1 - fraction)}`
+      this.fill.style.transition = transition
+      this.fill.style.height = `${fraction * 100}%`
+      this.button.style.transition = animate ? `${transition}, transform ${animate}ms ease` : "none"
+      this.button.style.color = fraction > 0 ? "var(--on-lime)" : ""
     },
 
     startHold() {
       if (this.given || this.timer) return
       this.el.classList.add("is-holding")
-      this.button.style.transition = `transform ${this.HOLD_MS}ms ease`
-      this.button.style.transform = "scale(1.18)"
+      // Set the transition (via setFill) before the transform it covers,
+      // so the button's very first hold picks it up rather than snapping.
       this.setFill(1, this.HOLD_MS)
+      this.button.style.transform = `scale(${this.HOLD_SCALE})`
       this.timer = setTimeout(() => this.complete(), this.HOLD_MS)
     },
 
@@ -321,9 +327,8 @@ let Hooks = {
       clearTimeout(this.timer)
       this.timer = null
       this.el.classList.remove("is-holding")
-      this.button.style.transition = "transform 250ms ease"
-      this.button.style.transform = "scale(1)"
       this.setFill(0, 250)
+      this.button.style.transform = "scale(1)"
     },
 
     complete() {
@@ -351,7 +356,6 @@ let Hooks = {
     markGiven() {
       this.el.classList.remove("is-holding")
       this.el.classList.add("is-given")
-      this.button.style.transition = "transform 250ms ease"
       this.button.style.transform = "scale(1)"
       this.setFill(1, false)
       if (this.labelEl) this.labelEl.textContent = "thanks!"

--- a/lib/blog/analytics.ex
+++ b/lib/blog/analytics.ex
@@ -109,7 +109,7 @@ defmodule Blog.Analytics do
 
   @doc """
   Records a "kudos" event for `path` -- a reader holding down the thumbs-up
-  button on a post for the full 5 seconds. `session_id` is optional and
+  button on a post for the full 3 seconds. `session_id` is optional and
   purely informational (matches `track/2`'s convention); double-submission
   is prevented upstream by `BlogWeb.KudosController`, not here.
   """

--- a/lib/blog_web/live/post_live/show.ex
+++ b/lib/blog_web/live/post_live/show.ex
@@ -83,33 +83,14 @@ defmodule BlogWeb.PostLive.Show do
           <button
             type="button"
             data-kudos-button
-            class="kudos-button relative flex h-10 w-10 shrink-0 items-center justify-center border border-ink text-ink transition-colors"
+            class="kudos-button relative flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden border border-ink text-ink transition-colors"
             aria-label="Give kudos"
-            title="Hold for 5 seconds to give kudos"
+            title="Hold for 3 seconds to give kudos"
           >
-            <svg
-              viewBox="0 0 36 36"
-              class="pointer-events-none absolute inset-0 h-full w-full -rotate-90"
-            >
-              <circle
-                cx="18"
-                cy="18"
-                r="15.5"
-                fill="none"
-                stroke="var(--color-rule)"
-                stroke-width="2"
-              />
-              <circle
-                data-kudos-progress
-                cx="18"
-                cy="18"
-                r="15.5"
-                fill="none"
-                stroke="var(--color-lime)"
-                stroke-width="2"
-                stroke-linecap="round"
-              />
-            </svg>
+            <span
+              data-kudos-fill
+              class="kudos-fill pointer-events-none absolute inset-x-0 bottom-0 h-0 bg-lime"
+            ></span>
             <svg
               viewBox="0 0 24 24"
               class="kudos-thumb pointer-events-none relative h-4 w-4"
@@ -158,16 +139,10 @@ defmodule BlogWeb.PostLive.Show do
       <div :if={@post.kind == "post"} class="mt-12 border-t border-ink pt-[18px]">
         <p class="label mb-2">Made it this far?</p>
         <.link
-          navigate={~p"/games/snake"}
+          navigate={~p"/sea"}
           class="font-display text-[22px] font-medium leading-[1.2] tracking-[-0.028em] !shadow-none hover:!bg-lime hover:!text-on-lime"
         >
-          Have a go at the game of snake →
-        </.link>
-        <.link
-          navigate={~p"/sea"}
-          class="mt-1 block font-display text-[22px] font-medium leading-[1.2] tracking-[-0.028em] !shadow-none hover:!bg-lime hover:!text-on-lime"
-        >
-          Or explore this site in 3D →
+          Explore this site in 3D →
         </.link>
       </div>
     </article>

--- a/test/blog_web/live/post_live_show_test.exs
+++ b/test/blog_web/live/post_live_show_test.exs
@@ -22,7 +22,7 @@ defmodule BlogWeb.PostLive.ShowTest do
     assert html =~ "<strong>bold</strong>"
   end
 
-  test "renders a note at /notes/:slug without the newsletter form or snake footer", %{
+  test "renders a note at /notes/:slug without the newsletter form or 3D CTA", %{
     conn: conn
   } do
     {:ok, _note} =
@@ -39,7 +39,24 @@ defmodule BlogWeb.PostLive.ShowTest do
 
     assert html =~ "My Note"
     refute html =~ "Newsletter signup"
-    refute html =~ "have a go at the game of"
+    refute html =~ "Explore this site in 3D"
+  end
+
+  test "a post's footer links to the 3D site and not to the snake game", %{conn: conn} do
+    {:ok, _post} =
+      Content.create_post(%{
+        title: "My Post",
+        slug: "my-post-3d",
+        body: "Body",
+        kind: "post",
+        published: true,
+        published_at: ~D[2024-01-01]
+      })
+
+    {:ok, _view, html} = live(conn, ~p"/blog/my-post-3d")
+
+    assert html =~ "Explore this site in 3D"
+    refute html =~ "snake"
   end
 
   test "footer omits view counts and shows the kudos widget when a post has no traffic yet", %{


### PR DESCRIPTION
Follow-up to #54 (already merged), tuning the kudos widget per feedback:

- **Hold duration**: 5s → 3s.
- **Fill direction**: replaced the thin circular progress ring with a bottom-to-top fill of the whole square button, so the button lands exactly on its "given" look (fully lime, on-lime icon) the instant the hold completes, instead of a separate ring-then-snap transition.
- **More pronounced growth**: the button now scales up to 1.5x during the hold (was a barely-noticeable 1.18x).
- **Post footer CTA**: "Made it this far?" now only links to "Explore this site in 3D" — dropped the snake game link.

Verified visually with Playwright screenshots at idle / mid-hold / completed-with-confetti, and `mix test` (125 tests), `mix format --check-formatted`, and `mix assets.build` all pass.

https://claude.ai/code/session_015XxqZZRAyWuDVPbeEzmNhh

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015XxqZZRAyWuDVPbeEzmNhh)_