### PR TITLE
Sea: emoji palette for the sail flag picker

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -413,9 +413,9 @@ pre code.hljs {
   border: 2px solid var(--color-ink); padding: 10px; }
 .sea-swatches { display: grid; grid-template-columns: repeat(4, 1fr); gap: 6px; }
 .sea-swatch { width: 22px; height: 22px; border: 2px solid var(--color-ink); cursor: pointer; padding: 0; }
-.sea-flag-btn { border: 2px solid var(--color-ink); background: var(--color-paper);
-  color: var(--color-ink); font-weight: 700; text-transform: uppercase; letter-spacing: .06em;
-  font-size: 11px; padding: 8px 10px; cursor: pointer; }
+.sea-flag-swatch { width: 26px; height: 26px; display: flex; align-items: center; justify-content: center;
+  font-size: 14px; line-height: 1; border: 2px solid var(--color-ink); background: var(--color-paper);
+  cursor: pointer; padding: 0; }
 
 /* Post footer kudos button (see the `Kudos` hook in app.js). [data-kudos-fill]
    (--color-lime) rises bottom-to-top over the 3s hold while the button

--- a/assets/js/sea/index.js
+++ b/assets/js/sea/index.js
@@ -49,6 +49,10 @@ const FISH_COUNT = 8
 const FISH_BOUNDS = 120 // flying fish patrol within this radius of the harbor
 const CUSTOM_COLOR_KEY = "seaCustomColor"
 const CUSTOM_FLAG_KEY = "seaCustomFlag"
+// Curated rather than free text, same reasoning as the hull PALETTE: a
+// fixed set keeps every sailor's picker rendering something every browser
+// actually has a glyph for.
+const FLAG_EMOJI = ["🏴", "🏳️", "🏁", "🚩", "⚓", "⛵", "🦈", "🐙", "🐬", "🌊", "⭐", "💀", "🔥", "🍀", "🌈", "⚡"]
 const BUOY_RESTING_SCALE = 3.2
 const BUOY_TARGET_SCALE = 4.6 // bigger than resting, marks the current target
 
@@ -710,10 +714,10 @@ class Sea {
     this.muteBtn.setAttribute("aria-label", this.audio.muted ? "Unmute sea sounds" : "Mute sea sounds")
   }
 
-  // Small hidden-by-default popover: a swatch per PALETTE color plus a
-  // "flag" button that prompts for an emoji, both applied immediately and
-  // persisted to localStorage. See the customColor/customFlag comment
-  // above for why this only affects this sailor's own view.
+  // Small hidden-by-default popover: a swatch per PALETTE color, then a
+  // swatch per FLAG_EMOJI option, both applied immediately and persisted to
+  // localStorage. See the customColor/customFlag comment above for why
+  // this only affects this sailor's own view.
   buildCustomizePanel() {
     const panel = document.createElement("div")
     panel.className = "sea-customize-panel"
@@ -737,20 +741,22 @@ class Sea {
     }
     panel.appendChild(swatches)
 
-    const flagBtn = document.createElement("button")
-    flagBtn.type = "button"
-    flagBtn.className = "sea-flag-btn"
-    flagBtn.textContent = "Set sail flag"
-    flagBtn.addEventListener("click", () => {
-      const chosen = window.prompt("Sail flag/emoji:", this.customFlag || "🏴")
-      if (chosen == null) return
-      const trimmed = chosen.trim()
-      this.customFlag = trimmed || null
-      if (trimmed) localStorage.setItem(CUSTOM_FLAG_KEY, trimmed)
-      else localStorage.removeItem(CUSTOM_FLAG_KEY)
-      this.scene.setSailTexture(this.selfBoat, flagTexture(trimmed || "🏴"))
-    })
-    panel.appendChild(flagBtn)
+    const flags = document.createElement("div")
+    flags.className = "sea-swatches"
+    for (const emoji of FLAG_EMOJI) {
+      const btn = document.createElement("button")
+      btn.type = "button"
+      btn.className = "sea-flag-swatch"
+      btn.textContent = emoji
+      btn.setAttribute("aria-label", `Set sail flag ${emoji}`)
+      btn.addEventListener("click", () => {
+        this.customFlag = emoji
+        localStorage.setItem(CUSTOM_FLAG_KEY, emoji)
+        this.scene.setSailTexture(this.selfBoat, flagTexture(emoji))
+      })
+      flags.appendChild(btn)
+    }
+    panel.appendChild(flags)
 
     return panel
   }


### PR DESCRIPTION
## Summary

Follow-up to the boat customization work in #57: the sail flag picker used `window.prompt` for free-text emoji entry. Replaced it with a clickable palette of 16 curated nautical/fun emoji, matching the hull-color swatch grid right above it.

## Changes

- `assets/js/sea/index.js` — `FLAG_EMOJI` constant (16 options); `buildCustomizePanel()` now renders a `.sea-swatches` grid of emoji buttons instead of a single "Set sail flag" button + prompt. Click applies immediately and persists to `localStorage`, same as before.
- `assets/css/app.css` — swaps `.sea-flag-btn` for `.sea-flag-swatch`, sized/laid out like the existing `.sea-swatch` color buttons.

## Testing

- Verified JS syntax with `node --input-type=module --check`.
- `mix test` — not runnable in this sandbox (no Elixir/Mix toolchain available); this change doesn't touch any Elixir, but please run CI before merging regardless.

---
🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01J9Atddo3Ti1xYJFzPWyK9t)_