### PR TITLE
Add kudos analytics tracking and display to admin dashboard

### DIFF
--- a/lib/blog_web/live/admin/analytics_live.ex
+++ b/lib/blog_web/live/admin/analytics_live.ex
@@ -317,24 +317,30 @@ defmodule BlogWeb.Admin.AnalyticsLive do
         country: blank_to_nil(socket.assigns.country_filter)
       ] ++ referrer_opts(socket.assigns.referrer_filter)
 
-    case Analytics.stats(from, to, opts) do
-      {:ok, report} ->
-        assign(socket,
-          summary: report.summary,
-          trend: report.trend,
-          top_paths: report.top_paths,
-          top_countries: report.top_countries,
-          top_referrers: report.top_referrers
-        )
+    socket =
+      case Analytics.stats(from, to, opts) do
+        {:ok, report} ->
+          assign(socket,
+            summary: report.summary,
+            trend: report.trend,
+            top_paths: report.top_paths,
+            top_countries: report.top_countries,
+            top_referrers: report.top_referrers
+          )
 
-      {:error, _reason} ->
-        assign(socket,
-          summary: %{views: 0, sessions: 0, avg_duration_seconds: nil},
-          trend: [],
-          top_paths: [],
-          top_countries: [],
-          top_referrers: []
-        )
+        {:error, _reason} ->
+          assign(socket,
+            summary: %{views: 0, sessions: 0, avg_duration_seconds: nil},
+            trend: [],
+            top_paths: [],
+            top_countries: [],
+            top_referrers: []
+          )
+      end
+
+    case Analytics.kudos_summary(from, to) do
+      {:ok, kudos} -> assign(socket, kudos_total: kudos.total, kudos_by_path: kudos.by_path)
+      {:error, _reason} -> assign(socket, kudos_total: 0, kudos_by_path: [])
     end
   end
 
@@ -563,7 +569,7 @@ defmodule BlogWeb.Admin.AnalyticsLive do
           </button>
         </div>
 
-        <div class="mb-10 grid grid-cols-3 gap-4 border-y border-ink py-6 text-center">
+        <div class="mb-10 grid grid-cols-2 gap-4 border-y border-ink py-6 text-center sm:grid-cols-4">
           <div>
             <div class="mark font-display text-[28px] font-bold text-ink">{@summary.views}</div>
             <div class="label mt-1">Page views</div>
@@ -577,6 +583,10 @@ defmodule BlogWeb.Admin.AnalyticsLive do
               {format_duration(@summary.avg_duration_seconds)}
             </div>
             <div class="label mt-1">Avg time on page</div>
+          </div>
+          <div>
+            <div class="mark font-display text-[28px] font-bold text-ink">{@kudos_total}</div>
+            <div class="label mt-1">Kudos</div>
           </div>
         </div>
 
@@ -709,6 +719,33 @@ defmodule BlogWeb.Admin.AnalyticsLive do
             </div>
             <div :if={truncated?(@top_countries)} class="mt-2 text-[11.5px] text-ink-3">
               Showing the top {list_limit()}. Narrow the filters above to see more.
+            </div>
+          </section>
+
+          <section class="sm:col-span-2">
+            <h2 class="label mb-3">Kudos by page</h2>
+            <div :if={@kudos_by_path == []} class="text-[13px] text-ink-3">No kudos yet.</div>
+            <div class="max-h-[380px] divide-y divide-rule overflow-y-auto border-t border-ink">
+              <button
+                :for={row <- @kudos_by_path}
+                type="button"
+                phx-click="set_filter"
+                phx-value-field="path"
+                phx-value-filter-value={row.path}
+                class={[
+                  "relative flex w-full items-center justify-between gap-4 py-2.5 text-left hover:bg-paper-2",
+                  @path_filter == row.path && "bg-paper-2"
+                ]}
+              >
+                <span
+                  class="absolute inset-y-0 left-0 z-0 bar-fill"
+                  style={"width: #{bar_pct(row.count, max_of(@kudos_by_path, :count))}%"}
+                ></span>
+                <span class="relative z-10 truncate text-[13px] text-ink">{row.path}</span>
+                <span class="relative z-10 shrink-0 text-[13px] text-ink-2">
+                  {row.count} kudos
+                </span>
+              </button>
             </div>
           </section>
 

--- a/test/blog_web/live/admin/analytics_live_test.exs
+++ b/test/blog_web/live/admin/analytics_live_test.exs
@@ -132,4 +132,54 @@ defmodule BlogWeb.Admin.AnalyticsLiveTest do
       refute html =~ "/via-google"
     end
   end
+
+  describe "kudos by page" do
+    test "shows kudos per path for the selected range, respecting the time filter", %{
+      conn: conn
+    } do
+      old = DateTime.add(DateTime.utc_now(), -60, :day)
+
+      Analytics.track_kudos("/kudos-recent-post", "sess-a")
+      Analytics.track_kudos("/kudos-recent-post", "sess-b")
+      :ok = Analytics.flush()
+
+      {:ok, _cols, _rows} =
+        Analytics.query(
+          "INSERT INTO events (occurred_at_us, event_name, path) VALUES ($1, 'kudos', $2)",
+          [DateTime.to_unix(old, :microsecond), "/kudos-old-post"]
+        )
+
+      {:ok, _view, html} = live(admin_conn(conn), ~p"/admin/analytics?range=7d")
+
+      assert html =~ "/kudos-recent-post"
+      assert html =~ "2 kudos"
+      refute html =~ "/kudos-old-post"
+
+      {:ok, _view, html_all} = live(admin_conn(conn), ~p"/admin/analytics?range=all")
+
+      assert html_all =~ "/kudos-recent-post"
+      assert html_all =~ "/kudos-old-post"
+    end
+
+    test "clicking a kudos row filters the whole report to that path", %{conn: conn} do
+      Analytics.track_kudos("/kudos-only-post", "sess-a")
+      :ok = Analytics.flush()
+
+      {:ok, view, html} = live(admin_conn(conn), ~p"/admin/analytics?range=all")
+      assert html =~ "/kudos-only-post"
+
+      html =
+        view
+        |> element("button[phx-value-filter-value='/kudos-only-post']")
+        |> render_click()
+
+      assert_patch(
+        view,
+        ~p"/admin/analytics?#{%{range: "all", referrer: "", path: "/kudos-only-post", country: ""}}"
+      )
+
+      assert html =~ "/kudos-only-post"
+      assert html =~ "Filtered by"
+    end
+  end
 end


### PR DESCRIPTION
## Summary
This PR adds kudos (appreciation/like) analytics tracking to the admin analytics dashboard, allowing administrators to see total kudos and a breakdown of kudos by page.

## Key Changes
- **Backend Analytics**: Added `Analytics.kudos_summary/2` function call to fetch kudos data for the selected date range, with proper error handling that defaults to empty state
- **Summary Stats**: Added a new "Kudos" metric card to the summary statistics section, displaying total kudos count
- **Responsive Grid**: Updated the summary stats grid from 3 columns to 2 columns on mobile with 4 columns on small screens and up (`grid-cols-2 sm:grid-cols-4`)
- **Kudos by Page Section**: Added a new "Kudos by page" section displaying:
  - List of pages with kudos counts
  - Visual bar chart representation using relative widths
  - Clickable rows that filter the entire report to that specific path
  - Empty state message when no kudos exist
- **Filter Integration**: Kudos by page rows are clickable and trigger the same filtering mechanism as other analytics sections
- **Test Coverage**: Added comprehensive tests for:
  - Kudos display respecting the selected time range
  - Kudos filtering by path
  - Proper handling of old vs. recent kudos data

## Implementation Details
- The kudos data is fetched in the same pattern as other analytics stats (summary, trend, top paths, etc.)
- Error handling follows the existing pattern with sensible defaults (0 total, empty list)
- The UI uses the same styling and interaction patterns as existing analytics sections for consistency
- The responsive design adapts the summary grid layout for better mobile viewing

https://claude.ai/code/session_01UJNjSxyCkCYv7V88HPtdar