### PR TITLE
Add an MCP server for remote post management

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,32 @@ mix phx.server       # http://localhost:4000
 Set `ADMIN_PASSWORD` (or use the `config :blog, :admin_password` dev/test
 default) to log in at `/admin/login`.
 
+## MCP server
+
+`POST /mcp` exposes a small [MCP](https://modelcontextprotocol.io) server
+(JSON-RPC 2.0 over plain HTTP, no SSE) so a remote MCP client -- Claude Code,
+Claude Desktop, claude.ai custom connectors, etc. -- can list, create, edit,
+publish, and delete posts without going through `/admin`. See `Blog.MCP` for
+the tool definitions (`list_posts`, `get_post`, `create_post`, `update_post`,
+`publish_post`, `unpublish_post`, `delete_post`, `preview_post`) and
+`BlogWeb.MCPController` for the JSON-RPC transport.
+
+It's guarded by a bearer token, independent of the `/admin` password -- set
+`MCP_API_TOKEN` (`config :blog, :mcp_api_token` in dev/test; generate a
+prod value with `openssl rand -hex 32`) and send it as
+`Authorization: Bearer <token>`. For example, with Claude Code:
+
+```bash
+claude mcp add --transport http blog https://your-host/mcp \
+  --header "Authorization: Bearer $MCP_API_TOKEN"
+```
+
 ## Deploying
 
 This app is a plain Elixir release (see `Dockerfile`) that reads
-`DATABASE_PATH`, `SECRET_KEY_BASE`, `ADMIN_PASSWORD`, and `PHX_HOST` from the
-environment, and expects its SQLite file on a persistent volume at
-`/data/app.db` — this matches
+`DATABASE_PATH`, `SECRET_KEY_BASE`, `ADMIN_PASSWORD`, `MCP_API_TOKEN`, and
+`PHX_HOST` from the environment, and expects its SQLite file on a persistent
+volume at `/data/app.db` — this matches
 [litehouse](https://github.com/danbruder/litehouse)'s app-volume convention,
 so `lh create blog --repo <owner>/blog` + `git push` is the intended way to
 ship it.

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -34,6 +34,10 @@ config :blog, BlogWeb.Endpoint,
 # ADMIN_PASSWORD environment variable (see runtime.exs).
 config :blog, :admin_password, "admin"
 
+# Dev-only MCP bearer token for POST /mcp. In prod this comes from the
+# MCP_API_TOKEN environment variable (see runtime.exs).
+config :blog, :mcp_api_token, "dev-mcp-token"
+
 config :blog, dev_routes: true
 
 config :logger, :console, format: "[$level] $message\n"

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -53,6 +53,18 @@ if config_env() == :prod do
            Set it to the password you'll use to log in to /admin.
            """)
 
+  # Bearer token for the POST /mcp API (see BlogWeb.Plugs.MCPAuth) that lets
+  # an MCP client create/edit/publish posts remotely. Generate one with
+  # `openssl rand -hex 32`.
+  config :blog,
+         :mcp_api_token,
+         System.get_env("MCP_API_TOKEN") ||
+           raise("""
+           environment variable MCP_API_TOKEN is missing.
+           Set it to a long random secret; MCP clients authenticate to /mcp
+           with `Authorization: Bearer <token>`.
+           """)
+
   config :blog, BlogWeb.Endpoint,
     url: [host: host, port: 443, scheme: "https"],
     # Allow LiveView sockets from every host this app is reachable at. Listing

--- a/config/test.exs
+++ b/config/test.exs
@@ -17,6 +17,8 @@ config :blog, BlogWeb.Endpoint,
 
 config :blog, :admin_password, "test-admin-password"
 
+config :blog, :mcp_api_token, "test-mcp-token"
+
 # Avoid real network calls to the geo-IP lookup service during tests.
 config :blog, :geoip_enabled, false
 

--- a/lib/blog/content.ex
+++ b/lib/blog/content.ex
@@ -29,6 +29,8 @@ defmodule Blog.Content do
 
   def get_post!(id), do: Repo.get!(Post, id)
 
+  def get_post(id), do: Repo.get(Post, id)
+
   def get_by_slug(slug) do
     Repo.get_by(Post, slug: slug)
   end

--- a/lib/blog/mcp.ex
+++ b/lib/blog/mcp.ex
@@ -1,0 +1,367 @@
+defmodule Blog.MCP do
+  @moduledoc """
+  Tool definitions and dispatch for the blog's MCP (Model Context Protocol)
+  server, so a remote MCP client can create/edit/publish posts without going
+  through the `/admin` UI. Deliberately free of any HTTP or JSON-RPC
+  concerns -- see `BlogWeb.MCPController` for the transport, and
+  `BlogWeb.Plugs.MCPAuth` for auth -- so tool behavior is testable as plain
+  Elixir.
+
+  Every tool returns `{:ok, result}` (a plain map, JSON-encodable by the
+  controller) or `{:error, message}` (a human-readable string sent back to
+  the calling model as a tool error, not a protocol error).
+  """
+
+  alias Blog.Content
+  alias Blog.Content.Post
+
+  @protocol_version "2024-11-05"
+
+  def protocol_version, do: @protocol_version
+
+  def server_info do
+    %{name: "danbruder-blog", version: Application.spec(:blog, :vsn) |> to_string()}
+  end
+
+  def tools do
+    [
+      %{
+        name: "list_posts",
+        description:
+          "List blog content (posts, notes, or pages), optionally filtered by kind and " <>
+            "publish status. Returns summaries without the markdown body.",
+        inputSchema: %{
+          type: "object",
+          properties: %{
+            kind: %{
+              type: "string",
+              enum: Post.kinds(),
+              description: "Only return content of this kind. Omit for all kinds."
+            },
+            status: %{
+              type: "string",
+              enum: ["all", "draft", "published"],
+              description: "Filter by publish status. Defaults to \"all\"."
+            }
+          }
+        }
+      },
+      %{
+        name: "get_post",
+        description:
+          "Fetch a single post/note/page by id or slug, including its full markdown body.",
+        inputSchema: %{
+          type: "object",
+          properties: %{
+            id: %{type: "integer", description: "Post id."},
+            slug: %{type: "string", description: "Post slug."}
+          }
+        }
+      },
+      %{
+        name: "create_post",
+        description:
+          "Create a new post/note/page. Defaults to an unpublished draft -- pass " <>
+            "published: true to publish immediately, or call publish_post afterwards.",
+        inputSchema: %{
+          type: "object",
+          properties: %{
+            title: %{type: "string"},
+            slug: %{
+              type: "string",
+              description:
+                "Lowercase letters, numbers, and hyphens only. Derived from the title if omitted."
+            },
+            body: %{type: "string", description: "Markdown body."},
+            kind: %{type: "string", enum: Post.kinds(), description: "Defaults to \"post\"."},
+            category: %{type: "string"},
+            tags: %{type: "string", description: "Comma-separated tags."},
+            published: %{type: "boolean", description: "Defaults to false (draft)."},
+            published_at: %{type: "string", description: "ISO 8601 date, e.g. 2026-08-30."}
+          },
+          required: ["title"]
+        }
+      },
+      %{
+        name: "update_post",
+        description:
+          "Update fields on an existing post/note/page, identified by id or slug. Only the " <>
+            "fields you pass are changed.",
+        inputSchema: %{
+          type: "object",
+          properties: %{
+            id: %{type: "integer", description: "Id of the post to update."},
+            slug: %{type: "string", description: "Current slug of the post to update."},
+            title: %{type: "string"},
+            new_slug: %{type: "string", description: "New slug value to rename the post to."},
+            body: %{type: "string"},
+            kind: %{type: "string", enum: Post.kinds()},
+            category: %{type: "string"},
+            tags: %{type: "string"},
+            published: %{type: "boolean"},
+            published_at: %{type: "string", description: "ISO 8601 date."}
+          }
+        }
+      },
+      %{
+        name: "publish_post",
+        description:
+          "Publish a draft, identified by id or slug. Sets published_at to today if it isn't " <>
+            "already set.",
+        inputSchema: %{
+          type: "object",
+          properties: %{
+            id: %{type: "integer"},
+            slug: %{type: "string"},
+            published_at: %{type: "string", description: "ISO 8601 date to use instead of today."}
+          }
+        }
+      },
+      %{
+        name: "unpublish_post",
+        description:
+          "Revert a post to draft (hidden from the public site) without deleting it, " <>
+            "identified by id or slug.",
+        inputSchema: %{
+          type: "object",
+          properties: %{id: %{type: "integer"}, slug: %{type: "string"}}
+        }
+      },
+      %{
+        name: "delete_post",
+        description:
+          "Permanently delete a post/note/page, identified by id or slug. This cannot be undone.",
+        inputSchema: %{
+          type: "object",
+          properties: %{id: %{type: "integer"}, slug: %{type: "string"}}
+        }
+      },
+      %{
+        name: "preview_post",
+        description:
+          "Render markdown to the same HTML the site would show, for previewing a body " <>
+            "(or an existing post's current body) before publishing.",
+        inputSchema: %{
+          type: "object",
+          properties: %{
+            body: %{
+              type: "string",
+              description: "Markdown to render. Takes precedence over id/slug."
+            },
+            id: %{type: "integer"},
+            slug: %{type: "string"}
+          }
+        }
+      }
+    ]
+  end
+
+  def call_tool(name, args) when is_map(args) do
+    dispatch(name, args)
+  rescue
+    e -> {:error, Exception.message(e)}
+  end
+
+  def call_tool(_name, _args), do: {:error, "arguments must be an object"}
+
+  defp dispatch("list_posts", args), do: list_posts(args)
+
+  defp dispatch("get_post", args),
+    do: with({:ok, post} <- find_post(args), do: {:ok, post_detail(post)})
+
+  defp dispatch("create_post", args), do: create_post(args)
+  defp dispatch("update_post", args), do: update_post(args)
+  defp dispatch("publish_post", args), do: publish_post(args)
+  defp dispatch("unpublish_post", args), do: set_published(args, false)
+  defp dispatch("delete_post", args), do: delete_post(args)
+  defp dispatch("preview_post", args), do: preview_post(args)
+  defp dispatch(other, _args), do: {:error, "unknown tool: #{other}"}
+
+  @statuses ~w(all draft published)
+
+  defp list_posts(args) do
+    kind = Map.get(args, "kind")
+    status = Map.get(args, "status", "all")
+
+    if status in @statuses do
+      posts =
+        Content.list_posts()
+        |> Enum.filter(&(is_nil(kind) or &1.kind == kind))
+        |> Enum.filter(&status_matches?(&1, status))
+        |> Enum.map(&post_summary/1)
+
+      {:ok, posts}
+    else
+      {:error, "invalid status: #{inspect(status)}"}
+    end
+  end
+
+  defp status_matches?(_post, "all"), do: true
+  defp status_matches?(post, "draft"), do: !post.published
+  defp status_matches?(post, "published"), do: post.published
+
+  defp create_post(args) do
+    case Map.get(args, "title") do
+      title when is_binary(title) and title != "" ->
+        attrs =
+          %{
+            "title" => title,
+            "slug" => Map.get(args, "slug") || slugify(title),
+            "body" => Map.get(args, "body", ""),
+            "kind" => Map.get(args, "kind", "post"),
+            "category" => Map.get(args, "category"),
+            "tags" => Map.get(args, "tags"),
+            "published" => Map.get(args, "published", false),
+            "published_at" => Map.get(args, "published_at")
+          }
+          |> reject_nil_values()
+
+        case Content.create_post(attrs) do
+          {:ok, post} -> {:ok, post_detail(post)}
+          {:error, changeset} -> {:error, changeset_errors(changeset)}
+        end
+
+      _ ->
+        {:error, "title is required"}
+    end
+  end
+
+  defp update_post(args) do
+    with {:ok, post} <- find_post(args) do
+      attrs =
+        %{
+          "title" => Map.get(args, "title"),
+          "slug" => Map.get(args, "new_slug"),
+          "body" => Map.get(args, "body"),
+          "kind" => Map.get(args, "kind"),
+          "category" => Map.get(args, "category"),
+          "tags" => Map.get(args, "tags"),
+          "published" => Map.get(args, "published"),
+          "published_at" => Map.get(args, "published_at")
+        }
+        |> reject_nil_values()
+
+      if map_size(attrs) == 0 do
+        {:ok, post_detail(post)}
+      else
+        case Content.update_post(post, attrs) do
+          {:ok, updated} -> {:ok, post_detail(updated)}
+          {:error, changeset} -> {:error, changeset_errors(changeset)}
+        end
+      end
+    end
+  end
+
+  defp publish_post(args) do
+    with {:ok, post} <- find_post(args) do
+      published_at = Map.get(args, "published_at") || post.published_at || Date.utc_today()
+
+      case Content.update_post(post, %{"published" => true, "published_at" => published_at}) do
+        {:ok, updated} -> {:ok, post_detail(updated)}
+        {:error, changeset} -> {:error, changeset_errors(changeset)}
+      end
+    end
+  end
+
+  defp set_published(args, published) do
+    with {:ok, post} <- find_post(args) do
+      case Content.update_post(post, %{"published" => published}) do
+        {:ok, updated} -> {:ok, post_detail(updated)}
+        {:error, changeset} -> {:error, changeset_errors(changeset)}
+      end
+    end
+  end
+
+  defp delete_post(args) do
+    with {:ok, post} <- find_post(args),
+         {:ok, deleted} <- Content.delete_post(post) do
+      {:ok, %{deleted: true, id: deleted.id, slug: deleted.slug}}
+    else
+      {:error, %Ecto.Changeset{} = changeset} -> {:error, changeset_errors(changeset)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp preview_post(args) do
+    case Map.get(args, "body") do
+      nil ->
+        with {:ok, post} <- find_post(args) do
+          {:ok, %{html: Content.render_body(post), excerpt: Content.excerpt(post)}}
+        end
+
+      body ->
+        {:ok, %{html: Content.render_markdown(body), excerpt: Content.excerpt(body)}}
+    end
+  end
+
+  defp find_post(args) do
+    cond do
+      id = Map.get(args, "id") -> find_by_id(id)
+      slug = Map.get(args, "slug") -> find_by_slug(slug)
+      true -> {:error, "id or slug is required"}
+    end
+  end
+
+  defp find_by_id(id) when is_integer(id) do
+    case Content.get_post(id) do
+      nil -> {:error, "no post with id #{id}"}
+      post -> {:ok, post}
+    end
+  end
+
+  defp find_by_id(id) when is_binary(id) do
+    case Integer.parse(id) do
+      {int, ""} -> find_by_id(int)
+      _ -> {:error, "id must be an integer"}
+    end
+  end
+
+  defp find_by_id(_id), do: {:error, "id must be an integer"}
+
+  defp find_by_slug(slug) when is_binary(slug) do
+    case Content.get_by_slug(slug) do
+      nil -> {:error, "no post with slug #{inspect(slug)}"}
+      post -> {:ok, post}
+    end
+  end
+
+  defp post_summary(%Post{} = post) do
+    %{
+      id: post.id,
+      title: post.title,
+      slug: post.slug,
+      kind: post.kind,
+      published: post.published,
+      published_at: post.published_at && Date.to_iso8601(post.published_at),
+      category: post.category,
+      tags: post.tags,
+      updated_at: post.updated_at && NaiveDateTime.to_iso8601(post.updated_at)
+    }
+  end
+
+  defp post_detail(%Post{} = post) do
+    Map.put(post_summary(post), :body, post.body)
+  end
+
+  defp reject_nil_values(map), do: Map.filter(map, fn {_k, v} -> not is_nil(v) end)
+
+  # Mirrors BlogWeb.Admin.PostFormLive's client-side "From title" slugify,
+  # for the same "spaces to hyphens" default when a caller doesn't pass one.
+  defp slugify(title) do
+    title
+    |> String.downcase()
+    |> String.replace(~r/[^a-z0-9\s-]/, "")
+    |> String.trim()
+    |> String.replace(~r/\s+/, "-")
+  end
+
+  defp changeset_errors(changeset) do
+    changeset
+    |> Ecto.Changeset.traverse_errors(fn {msg, opts} ->
+      Enum.reduce(opts, msg, fn {key, value}, acc ->
+        String.replace(acc, "%{#{key}}", to_string(value))
+      end)
+    end)
+    |> Enum.map_join("; ", fn {field, msgs} -> "#{field} #{Enum.join(msgs, ", ")}" end)
+  end
+end

--- a/lib/blog_web/controllers/mcp_controller.ex
+++ b/lib/blog_web/controllers/mcp_controller.ex
@@ -1,0 +1,70 @@
+defmodule BlogWeb.MCPController do
+  @moduledoc """
+  A minimal MCP (Model Context Protocol) server over the "Streamable HTTP"
+  transport: a single `POST /mcp` endpoint speaking JSON-RPC 2.0, guarded by
+  `BlogWeb.Plugs.MCPAuth`. Every response is a plain JSON object (no SSE) --
+  this server has no long-running or multi-message tool calls, so a
+  streaming response body would add complexity without buying anything.
+
+  Tool schemas and behavior live in `Blog.MCP`; this module only handles the
+  JSON-RPC envelope (requests vs. notifications, method routing, error
+  shapes).
+  """
+
+  use BlogWeb, :controller
+
+  alias Blog.MCP
+
+  def handle(conn, params) do
+    case Map.get(params, "id") do
+      nil -> send_resp(conn, 202, "")
+      id -> handle_request(conn, id, params)
+    end
+  end
+
+  defp handle_request(conn, id, %{"method" => method} = params) when is_binary(method) do
+    args = Map.get(params, "params", %{})
+
+    case dispatch(method, args) do
+      {:ok, result} ->
+        json(conn, %{jsonrpc: "2.0", id: id, result: result})
+
+      {:error, code, message} ->
+        json(conn, %{jsonrpc: "2.0", id: id, error: %{code: code, message: message}})
+    end
+  end
+
+  defp handle_request(conn, id, _params) do
+    json(conn, %{jsonrpc: "2.0", id: id, error: %{code: -32_600, message: "Invalid Request"}})
+  end
+
+  defp dispatch("initialize", _args) do
+    {:ok,
+     %{
+       protocolVersion: MCP.protocol_version(),
+       capabilities: %{tools: %{}},
+       serverInfo: MCP.server_info()
+     }}
+  end
+
+  defp dispatch("ping", _args), do: {:ok, %{}}
+
+  defp dispatch("tools/list", _args), do: {:ok, %{tools: MCP.tools()}}
+
+  defp dispatch("tools/call", %{"name" => name} = args) when is_binary(name) do
+    arguments = Map.get(args, "arguments", %{})
+
+    case MCP.call_tool(name, arguments) do
+      {:ok, result} ->
+        {:ok, %{content: [%{type: "text", text: Jason.encode!(result)}]}}
+
+      {:error, message} ->
+        {:ok, %{content: [%{type: "text", text: to_string(message)}], isError: true}}
+    end
+  end
+
+  defp dispatch("tools/call", _args),
+    do: {:error, -32_602, "Invalid params: \"name\" is required"}
+
+  defp dispatch(other, _args), do: {:error, -32_601, "Method not found: #{other}"}
+end

--- a/lib/blog_web/plugs/mcp_auth.ex
+++ b/lib/blog_web/plugs/mcp_auth.ex
@@ -1,0 +1,34 @@
+defmodule BlogWeb.Plugs.MCPAuth do
+  @moduledoc """
+  Bearer-token auth for the `/mcp` API. Separate from the cookie-session
+  `/admin` login (see `BlogWeb.AdminAuth`) since MCP clients are stateless,
+  non-browser callers that authenticate with a single long-lived secret
+  instead of logging in.
+  """
+
+  import Plug.Conn
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    with ["Bearer " <> token] <- get_req_header(conn, "authorization"),
+         true <- valid_token?(token) do
+      conn
+    else
+      _ ->
+        conn
+        |> put_status(:unauthorized)
+        |> Phoenix.Controller.json(%{
+          jsonrpc: "2.0",
+          id: nil,
+          error: %{code: -32_000, message: "Unauthorized"}
+        })
+        |> halt()
+    end
+  end
+
+  defp valid_token?(token) do
+    configured = Application.fetch_env!(:blog, :mcp_api_token)
+    Plug.Crypto.secure_compare(token, configured)
+  end
+end

--- a/lib/blog_web/router.ex
+++ b/lib/blog_web/router.ex
@@ -19,6 +19,11 @@ defmodule BlogWeb.Router do
     plug(:accepts, ["xml"])
   end
 
+  pipeline :mcp do
+    plug(:accepts, ["json"])
+    plug(BlogWeb.Plugs.MCPAuth)
+  end
+
   scope "/", BlogWeb do
     get("/healthz", HealthController, :show)
   end
@@ -54,6 +59,12 @@ defmodule BlogWeb.Router do
     get("/admin/login", AdminSessionController, :new)
     post("/admin/login", AdminSessionController, :create)
     delete("/admin/logout", AdminSessionController, :delete)
+  end
+
+  scope "/mcp", BlogWeb do
+    pipe_through(:mcp)
+
+    post("/", MCPController, :handle)
   end
 
   scope "/", BlogWeb do

--- a/test/blog/mcp_test.exs
+++ b/test/blog/mcp_test.exs
@@ -1,0 +1,223 @@
+defmodule Blog.MCPTest do
+  use Blog.DataCase, async: true
+
+  alias Blog.Content
+  alias Blog.MCP
+
+  @valid_attrs %{
+    title: "Hello world",
+    slug: "hello-world",
+    body: "**hi**",
+    kind: "post",
+    published: true,
+    published_at: nil
+  }
+
+  describe "list_posts" do
+    test "returns summaries, without the body, for every kind by default" do
+      {:ok, post} = Content.create_post(@valid_attrs)
+
+      assert {:ok, [summary]} = MCP.call_tool("list_posts", %{})
+      assert summary.id == post.id
+      assert summary.slug == "hello-world"
+      refute Map.has_key?(summary, :body)
+    end
+
+    test "filters by kind" do
+      {:ok, _post} = Content.create_post(@valid_attrs)
+      {:ok, note} = Content.create_post(%{@valid_attrs | slug: "a-note", kind: "note"})
+
+      assert {:ok, [summary]} = MCP.call_tool("list_posts", %{"kind" => "note"})
+      assert summary.id == note.id
+    end
+
+    test "filters by status" do
+      {:ok, published} = Content.create_post(@valid_attrs)
+      {:ok, draft} = Content.create_post(%{@valid_attrs | slug: "draft", published: false})
+
+      assert {:ok, [summary]} = MCP.call_tool("list_posts", %{"status" => "draft"})
+      assert summary.id == draft.id
+
+      assert {:ok, [summary]} = MCP.call_tool("list_posts", %{"status" => "published"})
+      assert summary.id == published.id
+    end
+
+    test "rejects an invalid status even with no posts in the database" do
+      assert {:error, message} = MCP.call_tool("list_posts", %{"status" => "bogus"})
+      assert message =~ "invalid status"
+    end
+  end
+
+  describe "get_post" do
+    test "returns the full post, including body, by id" do
+      {:ok, post} = Content.create_post(@valid_attrs)
+
+      assert {:ok, result} = MCP.call_tool("get_post", %{"id" => post.id})
+      assert result.body == "**hi**"
+    end
+
+    test "returns the full post by slug" do
+      {:ok, post} = Content.create_post(@valid_attrs)
+
+      assert {:ok, result} = MCP.call_tool("get_post", %{"slug" => "hello-world"})
+      assert result.id == post.id
+    end
+
+    test "errors when neither id nor slug is given" do
+      assert {:error, "id or slug is required"} = MCP.call_tool("get_post", %{})
+    end
+
+    test "errors when nothing matches" do
+      assert {:error, message} = MCP.call_tool("get_post", %{"slug" => "nope"})
+      assert message =~ "no post with slug"
+    end
+  end
+
+  describe "create_post" do
+    test "creates an unpublished draft by default" do
+      assert {:ok, result} = MCP.call_tool("create_post", %{"title" => "My New Post"})
+
+      assert result.title == "My New Post"
+      assert result.slug == "my-new-post"
+      assert result.published == false
+      assert result.kind == "post"
+    end
+
+    test "honors an explicit slug, kind, and published flag" do
+      assert {:ok, result} =
+               MCP.call_tool("create_post", %{
+                 "title" => "A Note",
+                 "slug" => "custom-slug",
+                 "kind" => "note",
+                 "body" => "hi",
+                 "published" => true,
+                 "published_at" => "2026-01-15"
+               })
+
+      assert result.slug == "custom-slug"
+      assert result.kind == "note"
+      assert result.published == true
+      assert result.published_at == "2026-01-15"
+    end
+
+    test "requires a title" do
+      assert {:error, "title is required"} = MCP.call_tool("create_post", %{})
+    end
+
+    test "surfaces a changeset error for a duplicate slug" do
+      {:ok, _} = Content.create_post(@valid_attrs)
+
+      assert {:error, message} =
+               MCP.call_tool("create_post", %{"title" => "Hello world", "slug" => "hello-world"})
+
+      assert message =~ "slug"
+    end
+  end
+
+  describe "update_post" do
+    test "updates only the given fields" do
+      {:ok, post} = Content.create_post(@valid_attrs)
+
+      assert {:ok, result} =
+               MCP.call_tool("update_post", %{"id" => post.id, "title" => "New title"})
+
+      assert result.title == "New title"
+      assert result.slug == "hello-world"
+    end
+
+    test "renames the slug via new_slug" do
+      {:ok, post} = Content.create_post(@valid_attrs)
+
+      assert {:ok, result} =
+               MCP.call_tool("update_post", %{"slug" => post.slug, "new_slug" => "renamed"})
+
+      assert result.slug == "renamed"
+    end
+
+    test "can flip published to false" do
+      {:ok, post} = Content.create_post(@valid_attrs)
+
+      assert {:ok, result} =
+               MCP.call_tool("update_post", %{"id" => post.id, "published" => false})
+
+      assert result.published == false
+    end
+
+    test "errors when the post doesn't exist" do
+      assert {:error, message} = MCP.call_tool("update_post", %{"id" => 999_999, "title" => "x"})
+      assert message =~ "no post with id"
+    end
+  end
+
+  describe "publish_post" do
+    test "publishes a draft and defaults published_at to today" do
+      {:ok, post} = Content.create_post(%{@valid_attrs | published: false, published_at: nil})
+
+      assert {:ok, result} = MCP.call_tool("publish_post", %{"id" => post.id})
+      assert result.published == true
+      assert result.published_at == Date.to_iso8601(Date.utc_today())
+    end
+
+    test "accepts an explicit published_at" do
+      {:ok, post} = Content.create_post(%{@valid_attrs | published: false})
+
+      assert {:ok, result} =
+               MCP.call_tool("publish_post", %{"id" => post.id, "published_at" => "2020-01-01"})
+
+      assert result.published_at == "2020-01-01"
+    end
+  end
+
+  describe "unpublish_post" do
+    test "sets published to false without touching other fields" do
+      {:ok, post} = Content.create_post(@valid_attrs)
+
+      assert {:ok, result} = MCP.call_tool("unpublish_post", %{"slug" => post.slug})
+      assert result.published == false
+      assert result.title == post.title
+    end
+  end
+
+  describe "delete_post" do
+    test "deletes the post" do
+      {:ok, post} = Content.create_post(@valid_attrs)
+
+      assert {:ok, %{deleted: true, id: id}} = MCP.call_tool("delete_post", %{"id" => post.id})
+      assert id == post.id
+      assert Content.get_post(post.id) == nil
+    end
+  end
+
+  describe "preview_post" do
+    test "renders a given markdown body" do
+      assert {:ok, %{html: html}} = MCP.call_tool("preview_post", %{"body" => "**hi**"})
+      assert html =~ "<strong>hi</strong>"
+    end
+
+    test "renders an existing post's body when no body is given" do
+      {:ok, post} = Content.create_post(@valid_attrs)
+
+      assert {:ok, %{html: html}} = MCP.call_tool("preview_post", %{"id" => post.id})
+      assert html =~ "<strong>hi</strong>"
+    end
+  end
+
+  test "call_tool/2 errors on an unknown tool name" do
+    assert {:error, "unknown tool: nope"} = MCP.call_tool("nope", %{})
+  end
+
+  test "tools/0 returns a schema for every dispatchable tool" do
+    names = MCP.tools() |> Enum.map(& &1.name)
+
+    assert names == [
+             "list_posts",
+             "get_post",
+             "create_post",
+             "update_post",
+             "publish_post",
+             "unpublish_post",
+             "delete_post",
+             "preview_post"
+           ]
+  end
+end

--- a/test/blog_web/mcp_controller_test.exs
+++ b/test/blog_web/mcp_controller_test.exs
@@ -1,0 +1,113 @@
+defmodule BlogWeb.MCPControllerTest do
+  use BlogWeb.ConnCase, async: true
+
+  alias Blog.Content
+
+  defp authed(conn) do
+    token = Application.fetch_env!(:blog, :mcp_api_token)
+    put_req_header(conn, "authorization", "Bearer #{token}")
+  end
+
+  defp rpc(conn, method, params \\ %{}, id \\ 1) do
+    body = %{"jsonrpc" => "2.0", "id" => id, "method" => method, "params" => params}
+    post(conn |> authed() |> put_req_header("content-type", "application/json"), ~p"/mcp", body)
+  end
+
+  test "rejects a request with no Authorization header", %{conn: conn} do
+    conn =
+      post(
+        put_req_header(conn, "content-type", "application/json"),
+        ~p"/mcp",
+        %{"jsonrpc" => "2.0", "id" => 1, "method" => "ping"}
+      )
+
+    assert conn.status == 401
+    assert json_response(conn, 401)["error"]["message"] == "Unauthorized"
+  end
+
+  test "rejects a request with the wrong token", %{conn: conn} do
+    conn =
+      conn
+      |> put_req_header("authorization", "Bearer wrong")
+      |> put_req_header("content-type", "application/json")
+      |> post(~p"/mcp", %{"jsonrpc" => "2.0", "id" => 1, "method" => "ping"})
+
+    assert conn.status == 401
+  end
+
+  test "a notification (no id) gets a 202 with no body", %{conn: conn} do
+    conn =
+      conn
+      |> authed()
+      |> put_req_header("content-type", "application/json")
+      |> post(~p"/mcp", %{"jsonrpc" => "2.0", "method" => "notifications/initialized"})
+
+    assert conn.status == 202
+    assert conn.resp_body == ""
+  end
+
+  test "initialize returns protocol version, capabilities, and server info", %{conn: conn} do
+    conn = rpc(conn, "initialize")
+    result = json_response(conn, 200)["result"]
+
+    assert result["protocolVersion"]
+    assert result["capabilities"] == %{"tools" => %{}}
+    assert result["serverInfo"]["name"] == "danbruder-blog"
+  end
+
+  test "ping returns an empty result", %{conn: conn} do
+    conn = rpc(conn, "ping")
+    assert json_response(conn, 200)["result"] == %{}
+  end
+
+  test "tools/list returns the tool schemas", %{conn: conn} do
+    conn = rpc(conn, "tools/list")
+    tools = json_response(conn, 200)["result"]["tools"]
+
+    assert Enum.any?(tools, &(&1["name"] == "create_post"))
+  end
+
+  test "an unknown method returns a JSON-RPC error", %{conn: conn} do
+    conn = rpc(conn, "not/a/method")
+    error = json_response(conn, 200)["error"]
+
+    assert error["code"] == -32_601
+    assert error["message"] =~ "Method not found"
+  end
+
+  test "tools/call round-trips create_post, get_post, and publish_post", %{conn: conn} do
+    create_conn =
+      rpc(conn, "tools/call", %{"name" => "create_post", "arguments" => %{"title" => "Hi there"}})
+
+    created = decode_tool_result(create_conn)
+    assert created["published"] == false
+    assert created["slug"] == "hi-there"
+
+    post_id = created["id"]
+
+    publish_conn =
+      rpc(conn, "tools/call", %{"name" => "publish_post", "arguments" => %{"id" => post_id}})
+
+    published = decode_tool_result(publish_conn)
+    assert published["published"] == true
+
+    assert Content.get_post(post_id).published == true
+  end
+
+  test "tools/call reports a tool-level error via isError, not a JSON-RPC error", %{conn: conn} do
+    conn = rpc(conn, "tools/call", %{"name" => "get_post", "arguments" => %{"slug" => "nope"}})
+    result = json_response(conn, 200)["result"]
+
+    assert result["isError"] == true
+    assert hd(result["content"])["text"] =~ "no post with slug"
+  end
+
+  defp decode_tool_result(conn) do
+    conn
+    |> json_response(200)
+    |> get_in(["result", "content"])
+    |> hd()
+    |> Map.fetch!("text")
+    |> Jason.decode!()
+  end
+end


### PR DESCRIPTION
POST /mcp is a small MCP (Model Context Protocol) server -- JSON-RPC 2.0
over plain HTTP, no SSE -- guarded by a bearer token (MCP_API_TOKEN,
independent of the /admin session password). It exposes list_posts,
get_post, create_post, update_post, publish_post, unpublish_post,
delete_post, and preview_post tools so a remote MCP client (Claude Code,
Claude Desktop, a claude.ai custom connector, etc.) can manage draft and
published posts without going through the /admin UI.

Blog.MCP holds the tool schemas and dispatch logic (pure Elixir, no
HTTP/JSON-RPC concerns); BlogWeb.MCPController handles the JSON-RPC
envelope; BlogWeb.Plugs.MCPAuth checks the bearer token. Also adds
Blog.Content.get_post/1, a non-raising counterpart to get_post!/1, for
looking posts up by id without raising on a miss.

Requires MCP_API_TOKEN to be set before deploying, the same way
ADMIN_PASSWORD and SECRET_KEY_BASE already are (see runtime.exs) --
generate one with `openssl rand -hex 32`.