### PR TITLE
Add an MCP server for remote post management

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,12 @@ the tool definitions (`list_posts`, `get_post`, `create_post`, `update_post`,
 `publish_post`, `unpublish_post`, `delete_post`, `preview_post`) and
 `BlogWeb.MCPController` for the JSON-RPC transport.
 
-It's guarded by a bearer token, independent of the `/admin` password -- set
-`MCP_API_TOKEN` (`config :blog, :mcp_api_token` in dev/test; generate a
-prod value with `openssl rand -hex 32`) and send it as
-`Authorization: Bearer <token>`. For example, with Claude Code:
+It's guarded by a bearer token, independent of the `/admin` password --
+optional, like `RESEND_API_KEY` below: set `MCP_API_TOKEN` (generate one
+with `openssl rand -hex 32`; dev/test use the `config :blog, :mcp_api_token`
+default instead) to turn it on, and send it as `Authorization: Bearer
+<token>`. Without it, `/mcp` just rejects every request -- the app boots
+fine either way. For example, with Claude Code:
 
 ```bash
 claude mcp add --transport http blog https://your-host/mcp \
@@ -44,9 +46,9 @@ claude mcp add --transport http blog https://your-host/mcp \
 ## Deploying
 
 This app is a plain Elixir release (see `Dockerfile`) that reads
-`DATABASE_PATH`, `SECRET_KEY_BASE`, `ADMIN_PASSWORD`, `MCP_API_TOKEN`, and
-`PHX_HOST` from the environment, and expects its SQLite file on a persistent
-volume at `/data/app.db` — this matches
+`DATABASE_PATH`, `SECRET_KEY_BASE`, `ADMIN_PASSWORD`, and `PHX_HOST` from the
+environment (`MCP_API_TOKEN` is optional -- see above), and expects its
+SQLite file on a persistent volume at `/data/app.db` — this matches
 [litehouse](https://github.com/danbruder/litehouse)'s app-volume convention,
 so `lh create blog --repo <owner>/blog` + `git push` is the intended way to
 ship it.

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -54,16 +54,10 @@ if config_env() == :prod do
            """)
 
   # Bearer token for the POST /mcp API (see BlogWeb.Plugs.MCPAuth) that lets
-  # an MCP client create/edit/publish posts remotely. Generate one with
-  # `openssl rand -hex 32`.
-  config :blog,
-         :mcp_api_token,
-         System.get_env("MCP_API_TOKEN") ||
-           raise("""
-           environment variable MCP_API_TOKEN is missing.
-           Set it to a long random secret; MCP clients authenticate to /mcp
-           with `Authorization: Bearer <token>`.
-           """)
+  # an MCP client create/edit/publish posts remotely. Optional: without it,
+  # /mcp just rejects every request (see MCPAuth.valid_token?/1) instead of
+  # the app failing to boot. Generate one with `openssl rand -hex 32`.
+  config :blog, :mcp_api_token, System.get_env("MCP_API_TOKEN")
 
   config :blog, BlogWeb.Endpoint,
     url: [host: host, port: 443, scheme: "https"],

--- a/lib/blog_web/plugs/mcp_auth.ex
+++ b/lib/blog_web/plugs/mcp_auth.ex
@@ -27,8 +27,13 @@ defmodule BlogWeb.Plugs.MCPAuth do
     end
   end
 
+  # No MCP_API_TOKEN configured means the feature is off -- reject every
+  # request rather than comparing against nil (or, worse, treating an unset
+  # token as "no auth required").
   defp valid_token?(token) do
-    configured = Application.fetch_env!(:blog, :mcp_api_token)
-    Plug.Crypto.secure_compare(token, configured)
+    case Application.get_env(:blog, :mcp_api_token) do
+      nil -> false
+      configured -> Plug.Crypto.secure_compare(token, configured)
+    end
   end
 end

--- a/test/blog_web/mcp_controller_test.exs
+++ b/test/blog_web/mcp_controller_test.exs
@@ -35,6 +35,22 @@ defmodule BlogWeb.MCPControllerTest do
     assert conn.status == 401
   end
 
+  test "rejects every request when MCP_API_TOKEN isn't configured (the app still boots)", %{
+    conn: conn
+  } do
+    original = Application.get_env(:blog, :mcp_api_token)
+    on_exit(fn -> Application.put_env(:blog, :mcp_api_token, original) end)
+    Application.put_env(:blog, :mcp_api_token, nil)
+
+    conn =
+      conn
+      |> put_req_header("authorization", "Bearer #{original}")
+      |> put_req_header("content-type", "application/json")
+      |> post(~p"/mcp", %{"jsonrpc" => "2.0", "id" => 1, "method" => "ping"})
+
+    assert conn.status == 401
+  end
+
   test "a notification (no id) gets a 202 with no body", %{conn: conn} do
     conn =
       conn


### PR DESCRIPTION
## Summary

Adds a remote MCP server so posts can be created, edited, published, and deleted without going through the `/admin` UI.

- **`POST /mcp`** — a JSON-RPC 2.0 endpoint (MCP's "Streamable HTTP" transport, plain JSON responses, no SSE), guarded by a bearer token independent of the `/admin` session password.
- **8 tools**: `list_posts`, `get_post`, `create_post` (defaults to an unpublished draft), `update_post`, `publish_post`, `unpublish_post`, `delete_post`, `preview_post` (renders markdown to HTML for previewing before publishing).
- `Blog.MCP` holds tool schemas/dispatch as plain Elixir (no HTTP concerns); `BlogWeb.MCPController` handles the JSON-RPC envelope; `BlogWeb.Plugs.MCPAuth` checks `Authorization: Bearer <token>`.
- New optional env var **`MCP_API_TOKEN`** — like `RESEND_API_KEY`, the app boots fine without it; `/mcp` just rejects every request until it's set. Generate one with `openssl rand -hex 32`.
- Also adds `Blog.Content.get_post/1`, a non-raising counterpart to `get_post!/1`.
- README documents setup and shows connecting via `claude mcp add --transport http`.

## Testing

No Elixir toolchain was preinstalled in this environment, so rather than eyeballing the change I built Erlang/OTP 27.3 from source and installed Elixir 1.17.3 (matching CI's versions) to actually compile and run the suite:

- `mix compile --warnings-as-errors` is clean.
- `mix test` passes: 172/172 (149 pre-existing + 23 new: unit tests on `Blog.MCP` plus HTTP-level controller tests covering auth — including the no-token-configured case — initialize/ping/tools-list, and a full create→publish round trip).
- One real bug caught by my own tests along the way: `list_posts`' status filter only validated `status` as a side effect of filtering posts, so an invalid status silently returned `[]` instead of erroring when the table was empty. Fixed by validating up front.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CJ8EcsEHT841SeWHvfrBw7)_